### PR TITLE
[feat]interfaceにdisabledを追加

### DIFF
--- a/services/soso-web/src/components/Button/Button.tsx
+++ b/services/soso-web/src/components/Button/Button.tsx
@@ -13,7 +13,7 @@ function Button(props: Props) {
     'px-4 py-2 text-white-0 font-bold text-md rounded-lg' +
     (props.className ? ` ${props.className}` : '');
   return (
-    <button className={clsx(className)} onClick={props.onClick}>
+    <button className={clsx(className)} onClick={props.onClick} disabled={props.disabled}>
       <div className={clsx('flex items-center')}>{props.children}</div>
     </button>
   );

--- a/services/soso-web/src/components/Button/Button.tsx
+++ b/services/soso-web/src/components/Button/Button.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 interface Props {
   className?: string;
+  disabled?: boolean;
   onClick?: () => void;
   children?: React.ReactNode;
 }


### PR DESCRIPTION
# 概要
TeamAddModalを作る際に、Buttonコンポーネントにdisabledというプロパティを渡す必要が出たので、ボタンコンポーネントのインタフェースを変更しました。
今後は任意でボタンコンポーネントを使う際にdisabled属性を使用できるようになります。

# 実装詳細
画面スクリーンショット等
テスト項目
[ ]
[ ]
[ ]
備考