### PR TITLE
Feat/kanba/make sos ocard

### DIFF
--- a/services/soso-web/src/components/SOSOList/SOSOList.stories.tsx
+++ b/services/soso-web/src/components/SOSOList/SOSOList.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SOSOList from './SOSOList';
+import { SOSOPointLog } from './SOSOList';
+
+const meta: Meta<typeof SOSOList> = {
+  title: 'Components/SOSOList',
+  component: SOSOList,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const mockLogs: SOSOPointLog[] = [
+  {
+    id: 1,
+    eventName: '歓送迎会',
+    date: '2024/04/15',
+    time: '22:00',
+    changer: '佐藤花子',
+    changee: '田中太郎',
+    sosoPoints: -1,
+    reason: 'みんなの分のタクシーを手配してくれた',
+  },
+  {
+    id: 2,
+    eventName: '新歓コンパ',
+    date: '2024/04/15',
+    time: '21:15',
+    changer: '山田次郎',
+    changee: '鈴木三郎',
+    sosoPoints: 2,
+    reason: 'カラオケで大声で歌いすぎた',
+  },
+  {
+    id: 3,
+    eventName: '新歓コンパ',
+    date: '2024/04/15',
+    time: '20:30',
+    changer: '田中太郎',
+    changee: '佐藤花子',
+    sosoPoints: 3,
+    reason: 'お酒をこぼして服を汚した',
+  },
+  {
+    id: 4,
+    eventName: '歓送迎会',
+    date: '2024/04/10',
+    time: '23:45',
+    changer: '鈴木三郎',
+    changee: '山田次郎',
+    sosoPoints: 1,
+    reason: '二次会で道に迷って遅刻させた',
+  },
+];
+
+export const Default: Story = {
+  args: {
+    logs: mockLogs,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    logs: [],
+  },
+};

--- a/services/soso-web/src/components/SOSOList/SOSOList.tsx
+++ b/services/soso-web/src/components/SOSOList/SOSOList.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import SOSOcard from './SOSOListCard'; // SOSOcardコンポーネントをインポート
+
+// SOSOポイント変動履歴のデータの型を定義
+export interface SOSOPointLog {
+  id: number | string;
+  eventName: string; // 画像のようにイベント名も表示
+  date: string;
+  time: string;
+  changer: string;
+  changee: string;
+  sosoPoints: number;
+  reason: string;
+}
+
+// SOSOListが受け取るpropsの型
+interface SOSOListProps {
+  logs: SOSOPointLog[]; // SOSOPointLogの配列
+}
+
+function SOSOList({ logs }: SOSOListProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      {/* logs配列をループして、SOSOcardを生成 */}
+      {logs.map((log) => (
+        <SOSOcard
+          key={log.id} // 各要素にユニークなkeyを指定
+          date={log.date}
+          time={log.time}
+          changer={log.changer}
+          changee={log.changee}
+          sosoPoints={log.sosoPoints}
+          reason={log.reason}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default SOSOList;

--- a/services/soso-web/src/components/SOSOList/SOSOList.tsx
+++ b/services/soso-web/src/components/SOSOList/SOSOList.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import SOSOcard from './SOSOListCard'; // SOSOcardコンポーネントをインポート
 
 // SOSOポイント変動履歴のデータの型を定義
-export interface SOSOPointLog {
+export interface SOSOTransaction {
   id: number | string;
   eventName: string; // 画像のようにイベント名も表示
   date: string;
@@ -16,7 +16,7 @@ export interface SOSOPointLog {
 
 // SOSOListが受け取るpropsの型
 interface SOSOListProps {
-  logs: SOSOPointLog[]; // SOSOPointLogの配列
+  logs: SOSOTransaction[]; // SOSOTransactionの配列
 }
 
 function SOSOList({ logs }: SOSOListProps) {

--- a/services/soso-web/src/components/SOSOList/SOSOList.tsx
+++ b/services/soso-web/src/components/SOSOList/SOSOList.tsx
@@ -1,3 +1,4 @@
+//SOSOList.tsx
 import React from 'react';
 import SOSOcard from './SOSOListCard'; // SOSOcardコンポーネントをインポート
 

--- a/services/soso-web/src/components/SOSOList/SOSOListCard.stories.tsx
+++ b/services/soso-web/src/components/SOSOList/SOSOListCard.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SOSOcard from './SOSOListCard';
+
+// Storybookの基本設定
+const meta = {
+  title: 'Components/SOSOcard',
+  component: SOSOcard,
+  tags: ['autodocs'],
+} satisfies Meta<typeof SOSOcard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// 1. ポイント付与（プラス）のストーリー
+export const PointAdded: Story = {
+  args: {
+    date: '2024/04/15',
+    time: '21:10',
+    changer: '山田次郎',
+    changee: '鈴木三郎',
+    sosoPoints: 1,
+    reason: 'カラオケで大声で歌いすぎた',
+  },
+};
+
+// 2. ポイント減算（マイナス）のストーリー
+export const PointDeducted: Story = {
+  args: {
+    date: '2024/04/15',
+    time: '22:00',
+    changer: '佐藤花子',
+    changee: '田中太郎',
+    sosoPoints: -1,
+    reason: 'みんなの分のタクシーを手配してくれた',
+  },
+};
+
+// 3. ポイント変動なし（ゼロ）のストーリー
+export const NoChange: Story = {
+  args: {
+    date: '2024/04/16',
+    time: '09:00',
+    changer: '管理者',
+    changee: '全員',
+    sosoPoints: 0,
+    reason: '定期メンテナンス',
+  },
+};

--- a/services/soso-web/src/components/SOSOList/SOSOListCard.tsx
+++ b/services/soso-web/src/components/SOSOList/SOSOListCard.tsx
@@ -1,0 +1,23 @@
+import clsx from 'clsx';
+import React from 'react';
+import Button from '../Button/Button';
+
+interface Props {
+  className?: string;
+  date: Date;
+  changer: string;
+  changee: string;
+  sosoPoints: number;
+  reason: string;
+}
+
+interface Props {
+  className?: string;
+  calenderName?: string;
+  eventName?: string;
+  driveState?: DriveState;
+  eventDate?: string;
+  driveTime?: string;
+  passengerNumber?: number;
+  children?: React.ReactNode;
+}

--- a/services/soso-web/src/components/SOSOList/SOSOListCard.tsx
+++ b/services/soso-web/src/components/SOSOList/SOSOListCard.tsx
@@ -1,3 +1,4 @@
+//SOSOListCard.tsx
 import clsx from 'clsx';
 import React from 'react';
 

--- a/services/soso-web/src/components/SOSOList/SOSOListCard.tsx
+++ b/services/soso-web/src/components/SOSOList/SOSOListCard.tsx
@@ -1,23 +1,33 @@
 import clsx from 'clsx';
 import React from 'react';
-import Button from '../Button/Button';
+
 
 interface Props {
   className?: string;
-  date: Date;
+  date: string;
+  time: string;
   changer: string;
   changee: string;
   sosoPoints: number;
   reason: string;
 }
 
-interface Props {
-  className?: string;
-  calenderName?: string;
-  eventName?: string;
-  driveState?: DriveState;
-  eventDate?: string;
-  driveTime?: string;
-  passengerNumber?: number;
-  children?: React.ReactNode;
+
+function SOSOcard({ className, date, time, changer, changee, sosoPoints, reason }: Props) {
+  const pointTextColor = sosoPoints >= 0 ? 'text-green-600' : 'text-red-600';
+  const pointText = sosoPoints > 0 ? `+${sosoPoints}pt` : `${sosoPoints}pt`;
+
+
+  return (
+    <div className={clsx('bg-gray-50 rounded-md p-3 shadow-sm', className)}>
+      <div className="text-xs text-gray-500 mb-1">{date} {time}</div>
+      <p className="text-sm font-semibold text-gray-800">
+        {changer} が {changee} のSOSOポイントを <span className={pointTextColor}>{pointText}</span> 変更
+      </p>
+      <p className="text-xs text-gray-600">理由: {reason}</p>
+    </div>
+  );
 }
+
+
+export default SOSOcard;


### PR DESCRIPTION
# 概要
[ここに、このPRが解決する問題や目的を簡潔に記述します。]
例：ユーザーが過去のSOSOポイント変動履歴を一覧で確認できる機能を追加しました。

# 実装内容
SOSOcard コンポーネントの作成：SOSOポイント変動履歴1件分の情報を表示するUIコンポーネントです。

SOSOList コンポーネントの作成：複数のSOSOcardをリストとして表示するためのコンテナコンポーネントです。

型定義の追加：SOSOPointLog インターフェースを定義し、データの構造を明確にしました。

Storybookの追加：SOSOcard と SOSOList の表示パターン（データあり、データなし、ポイントの増減など）をテストするためのストーリーを追加しました。

画面スクリーンショット等
テスト項目
あらかじめ以下を実行してください。

npm install

npm run storybook

以下の項目を確認してください。

[ ] SOSOList のストーリーで、複数の履歴が正しく表示されること。

[ ] SOSOcard のストーリーで、ポイントがプラスの場合は緑色、マイナスの場合は赤色で表示されること。

[ ] SOSOList のストーリーで、履歴が空の場合に何も表示されないこと。

備考
[ここに、レビュアーに伝えておきたいことや、今後の課題などを記述します。]
例：APIからのデータ取得は別途実装予定のため、今回はモックデータを使用しています。
