### PR TITLE
Feature/kitano/calender-create-api

### DIFF
--- a/services/soso-api/api/swagger.yaml
+++ b/services/soso-api/api/swagger.yaml
@@ -838,12 +838,12 @@ components:
 
     LoginRequest:
       type: object
-      required: [username, password]
+      required: [mailAddress, password]
       properties:
-        username:
+        mailAddress:
           type: string
-          description: ログインID
-          example: kitano_masaki
+          description: メールアドレス
+          example: hoge@example.com
         password:
           type: string
           format: password

--- a/services/soso-api/init/001_init.sql
+++ b/services/soso-api/init/001_init.sql
@@ -14,7 +14,7 @@ CREATE TABLE `users` (
 -- 2. calenders テーブル
 CREATE TABLE `calenders` (
   `id`             VARCHAR(36)       NOT NULL,
-  `name`           VARCHAR(128)      NOT NULL,
+  `name`           VARCHAR(128)      NOT NULL UNIQUE,
   `description`    TEXT,
   `owner_id`       VARCHAR(36)       NOT NULL,
   `created_at`     DATETIME(6)       NOT NULL DEFAULT CURRENT_TIMESTAMP(6),

--- a/services/soso-api/init/001_init.sql
+++ b/services/soso-api/init/001_init.sql
@@ -11,8 +11,8 @@ CREATE TABLE `users` (
   PRIMARY KEY(`id`)
 );
 
--- 2. teams テーブル
-CREATE TABLE `teams` (
+-- 2. calenders テーブル
+CREATE TABLE `calenders` (
   `id`             VARCHAR(36)       NOT NULL,
   `name`           VARCHAR(128)      NOT NULL,
   `description`    TEXT,
@@ -20,23 +20,23 @@ CREATE TABLE `teams` (
   `created_at`     DATETIME(6)       NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at`     DATETIME(6)       NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`id`),
-  INDEX `idx_teams_owner` (`owner_id`),
-  CONSTRAINT `fk_teams_owner`
+  INDEX `idx_calenders_owner` (`owner_id`),
+  CONSTRAINT `fk_calenders_owner`
     FOREIGN KEY (`owner_id`) REFERENCES `users`(`id`)
     ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 3. team_memberships テーブル
-CREATE TABLE `team_memberships` (
-  `team_id`        VARCHAR(36)               NOT NULL,
+-- 3. calender_memberships テーブル
+CREATE TABLE `calender_memberships` (
+  `calender_id`        VARCHAR(36)               NOT NULL,
   `user_id`        VARCHAR(36)               NOT NULL,
   `role`           ENUM('member','admin')    NOT NULL DEFAULT 'member',
   `soso_point`     INT                       NOT NULL DEFAULT 0,
   `joined_at`      DATETIME(6)               NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-  PRIMARY KEY (`team_id`,`user_id`),
+  PRIMARY KEY (`calender_id`,`user_id`),
   INDEX `idx_tm_user` (`user_id`),
-  CONSTRAINT `fk_tm_team`
-    FOREIGN KEY (`team_id`) REFERENCES `teams`(`id`)
+  CONSTRAINT `fk_tm_calender`
+    FOREIGN KEY (`calender_id`) REFERENCES `calenders`(`id`)
     ON DELETE CASCADE,
   CONSTRAINT `fk_tm_user`
     FOREIGN KEY (`user_id`) REFERENCES `users`(`id`)
@@ -46,7 +46,7 @@ CREATE TABLE `team_memberships` (
 -- 4. reservations テーブル
 CREATE TABLE `reservations` (
   `id`                   VARCHAR(36)       NOT NULL,
-  `team_id`              VARCHAR(36)       NOT NULL,
+  `calender_id`              VARCHAR(36)       NOT NULL,
   `creator_id`           VARCHAR(36)       NOT NULL,
   `title`                VARCHAR(128)      NOT NULL,
   `description`          TEXT,
@@ -58,9 +58,9 @@ CREATE TABLE `reservations` (
   `created_at`           DATETIME(6)       NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at`           DATETIME(6)       NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`id`),
-  INDEX `idx_reservations_team` (`team_id`),
-  CONSTRAINT `fk_reservations_team`
-    FOREIGN KEY (`team_id`) REFERENCES `teams`(`id`)
+  INDEX `idx_reservations_calender` (`calender_id`),
+  CONSTRAINT `fk_reservations_calender`
+    FOREIGN KEY (`calender_id`) REFERENCES `calenders`(`id`)
     ON DELETE CASCADE,
   CONSTRAINT `fk_reservations_creator`
     FOREIGN KEY (`creator_id`) REFERENCES `users`(`id`)
@@ -99,7 +99,7 @@ CREATE TABLE refresh_tokens (
 -- 7. soso_point_histories テーブル
 CREATE TABLE `soso_point_histories` (
   `id`             BIGINT AUTO_INCREMENT PRIMARY KEY,
-  `team_id`        VARCHAR(36) NOT NULL,
+  `calender_id`        VARCHAR(36) NOT NULL,
   `user_id`        VARCHAR(36) NOT NULL,
   `changed_at`     DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `changed_by`     VARCHAR(36),  -- 操作したユーザー（NULL = システム）
@@ -110,11 +110,11 @@ CREATE TABLE `soso_point_histories` (
   `reason`         TEXT,  -- 操作理由の自由記述欄
 
   INDEX `idx_sph_user` (`user_id`),
-  INDEX `idx_sph_team` (`team_id`),
+  INDEX `idx_sph_calender` (`calender_id`),
   INDEX `idx_sph_reservation` (`reservation_id`),
 
-  CONSTRAINT `fk_sph_team`
-    FOREIGN KEY (`team_id`) REFERENCES `teams`(`id`)
+  CONSTRAINT `fk_sph_calender`
+    FOREIGN KEY (`calender_id`) REFERENCES `calenders`(`id`)
     ON DELETE CASCADE,
   CONSTRAINT `fk_sph_user`
     FOREIGN KEY (`user_id`) REFERENCES `users`(`id`)

--- a/services/soso-api/internal/config/router.go
+++ b/services/soso-api/internal/config/router.go
@@ -32,6 +32,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 
 	userRepo := &repository.UserRepository{DB: db}
 	rtRepo := &repository.RefreshTokenRepository{DB: db}
+	calRepo := &repository.CalenderRepository{DB: db}
 
 	cookieCfg := handlers.CookieConf{
 		Name:     cfg.CookieNameRT,
@@ -42,6 +43,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	}
 	authH := handlers.NewAuthHandler(userRepo, rtRepo, cfg.JWTSigningKey, cfg.AccessTokenTTLMin, cfg.RefreshTokenTTLH, cookieCfg)
 	userH := handlers.NewUserHandler(userRepo)
+	calenderH := handlers.NewCalenderHandler(calRepo)
 
 	// Echo標準ミドルウェア
 	e.Use(echoMW.Logger())
@@ -105,8 +107,13 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	usersG := e.Group("/users", csrfMW)
 	usersG.POST("/register", userH.Register)
 
+	// Users
 	usersPriv := usersG.Group("", echojwt.WithConfig(jwtCfg)) // 同じ /users 配下
 	usersPriv.GET("/me", userH.Me)
+
+	// Calenders
+	calG := e.Group("/calenders", csrfMW, echojwt.WithConfig(jwtCfg))
+	calG.POST("/create", calenderH.Create)
 
 	// シャットダウン時クローズ
 	e.Server.RegisterOnShutdown(func() { _ = db.Close() })

--- a/services/soso-api/internal/config/router.go
+++ b/services/soso-api/internal/config/router.go
@@ -84,17 +84,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 		return c.JSON(http.StatusOK, map[string]string{"csrf_token": token})
 	}, csrfMW)
 
-	// /auth
-	authG := e.Group("/auth", csrfMW)
-	authG.POST("/login", authH.Login)
-	authG.POST("/refresh", authH.Refresh)
-	authG.POST("/logout", authH.Logout)
-
-	// /users 公開
-	usersG := e.Group("/users", csrfMW)
-	usersG.POST("/register", userH.Register)
-
-	// /users 認証必須
+	// JWT認証
 	jwtCfg := echojwt.Config{
 		SigningKey: []byte(cfg.JWTSigningKey),
 		NewClaimsFunc: func(c echo.Context) jwt.Claims {
@@ -104,6 +94,17 @@ func SetupRouter(cfg *Config) *echo.Echo {
 			return echo.NewHTTPError(http.StatusUnauthorized, "invalid or expired token")
 		},
 	}
+
+	// /auth
+	authG := e.Group("/auth", csrfMW)
+	authG.POST("/login", authH.Login)
+	authG.POST("/refresh", authH.Refresh)
+	authG.POST("/logout", authH.Logout, echojwt.WithConfig(jwtCfg))
+
+	// /users 公開
+	usersG := e.Group("/users", csrfMW)
+	usersG.POST("/register", userH.Register)
+
 	usersPriv := usersG.Group("", echojwt.WithConfig(jwtCfg)) // 同じ /users 配下
 	usersPriv.GET("/me", userH.Me)
 

--- a/services/soso-api/internal/handlers/calender.go
+++ b/services/soso-api/internal/handlers/calender.go
@@ -23,7 +23,7 @@ type CalenderCreateRequest struct {
 	Description string `json:"description" validate:"description"`
 }
 
-func (h *CalenderHandler) Resister(c echo.Context) error {
+func (h *CalenderHandler) Create(c echo.Context) error {
 	var req CalenderCreateRequest
 
 	tok, ok := c.Get("user").(*jwt.Token)

--- a/services/soso-api/internal/handlers/calender.go
+++ b/services/soso-api/internal/handlers/calender.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"net/http"
+	"soso/internal/model"
+	"soso/internal/repository"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+type CalenderHandler struct {
+	CalenderRepo *repository.CalenderRepository
+}
+
+func NewCalenderHandler(r *repository.CalenderRepository) *CalenderHandler {
+	return &CalenderHandler{CalenderRepo: r}
+}
+
+type CalenderCreateRequest struct {
+	Name        string `json:"name" validate:"required,name"`
+	Description string `json:"description" validate:"description"`
+}
+
+func (h *CalenderHandler) Resister(c echo.Context) error {
+	var req CalenderCreateRequest
+
+	tok, ok := c.Get("user").(*jwt.Token)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+	}
+	claims, ok := tok.Claims.(*jwt.RegisteredClaims)
+	if !ok || claims.Subject == "" {
+		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+	}
+	ownerId := claims.Subject
+
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid payload")
+	}
+	if err := c.Validate(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	ctx := c.Request().Context()
+	if exist, err := h.CalenderRepo.FindByName(ctx, req.Name); err != nil {
+		return err
+	} else if exist != nil {
+		return echo.NewHTTPError(http.StatusConflict, "Calender name already exists")
+	}
+
+	ca := &model.Calender{
+		ID:          uuid.NewString(),
+		Name:        req.Name,
+		Description: req.Description,
+		OwnerId:     ownerId,
+	}
+
+	if err := h.CalenderRepo.Create(ctx, ca); err != nil {
+		return err
+	}
+	return c.NoContent(http.StatusCreated)
+}

--- a/services/soso-api/internal/handlers/calender.go
+++ b/services/soso-api/internal/handlers/calender.go
@@ -59,5 +59,10 @@ func (h *CalenderHandler) Create(c echo.Context) error {
 	if err := h.CalenderRepo.Create(ctx, ca); err != nil {
 		return err
 	}
-	return c.NoContent(http.StatusCreated)
+	return c.JSON(http.StatusCreated, map[string]any{
+		"id":          ca.ID,
+		"name":        ca.Name,
+		"description": ca.Description,
+		"ownerId":     ca.OwnerId,
+	})
 }

--- a/services/soso-api/internal/handlers/user.go
+++ b/services/soso-api/internal/handlers/user.go
@@ -78,8 +78,6 @@ func (h *UserHandler) Register(c echo.Context) error {
 		"mailAddress": u.MailAddress,
 		"hasCar":      u.HasCar,
 		"capacity":    u.Capacity,
-		"createdAt":   u.CreatedAt,
-		"updatedAt":   u.UpdatedAt,
 	})
 }
 

--- a/services/soso-api/internal/handlers/user.go
+++ b/services/soso-api/internal/handlers/user.go
@@ -41,7 +41,7 @@ func (h *UserHandler) Register(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	// 相関バリデーション（HasCar=true の時 Capacity>0）
-	if req.HasCar && req.Capacity == 0 {
+	if req.HasCar && req.Capacity <= 0 {
 		return echo.NewHTTPError(http.StatusBadRequest, "capacity required when has_car is true")
 	}
 
@@ -72,7 +72,15 @@ func (h *UserHandler) Register(c echo.Context) error {
 	if err := h.UserRepo.Create(ctx, u); err != nil {
 		return err
 	}
-	return c.NoContent(http.StatusCreated)
+	return c.JSON(http.StatusCreated, map[string]any{
+		"id":          u.ID,
+		"username":    u.Username,
+		"mailAddress": u.MailAddress,
+		"hasCar":      u.HasCar,
+		"capacity":    u.Capacity,
+		"createdAt":   u.CreatedAt,
+		"updatedAt":   u.UpdatedAt,
+	})
 }
 
 // GET /users/me

--- a/services/soso-api/internal/model/calender.go
+++ b/services/soso-api/internal/model/calender.go
@@ -1,0 +1,14 @@
+package model
+
+import (
+	"time"
+)
+
+type Calender struct {
+	ID          string    `db:"id"`
+	Name        string    `db:"name"`
+	Description string    `db:"description"`
+	OwnerId     string    `db:"owner_id"`
+	CreatedAt   time.Time `db:"created_at"`
+	UpdatedAt   time.Time `db:"updated_at"`
+}

--- a/services/soso-api/internal/repository/calender.go
+++ b/services/soso-api/internal/repository/calender.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"soso/internal/model"
 )
 
@@ -12,6 +13,32 @@ type CalenderRepository struct {
 
 func NewCalenderRepository(db *sql.DB) *CalenderRepository {
 	return &CalenderRepository{DB: db}
+}
+
+func (r *CalenderRepository) FindByName(ctx context.Context, name string) (*model.Calender, error) {
+	row := r.DB.QueryRowContext(ctx, `
+		SELECT
+			id,
+			name,
+			description,
+			owner_id,
+			created_at,
+			updated_at
+		FROM calenders
+		WHERE name = ?
+		LIMIT 1
+	`, name)
+
+	var c model.Calender
+	if err := row.Scan(
+		&c.ID, &c.Name, &c.Description, &c.OwnerId, &c.CreatedAt, &c.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &c, nil
 }
 
 func (r *CalenderRepository) Create(ctx context.Context, c *model.Calender) error {

--- a/services/soso-api/internal/repository/calender.go
+++ b/services/soso-api/internal/repository/calender.go
@@ -45,7 +45,7 @@ func (r *CalenderRepository) Create(ctx context.Context, c *model.Calender) erro
 	_, err := r.DB.ExecContext(ctx, `
 		INSERT INTO calenders (
 			id, name, description, owner_id
-		VALUES (?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?)
 		)
 	`, c.ID, c.Name, c.Description, c.OwnerId)
 	return err

--- a/services/soso-api/internal/repository/calender.go
+++ b/services/soso-api/internal/repository/calender.go
@@ -1,0 +1,25 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"soso/internal/model"
+)
+
+type CalenderRepository struct {
+	DB *sql.DB
+}
+
+func NewCalenderRepository(db *sql.DB) *CalenderRepository {
+	return &CalenderRepository{DB: db}
+}
+
+func (r *CalenderRepository) Create(ctx context.Context, c *model.Calender) error {
+	_, err := r.DB.ExecContext(ctx, `
+		INSERT INTO calenders (
+			id, name, description, owner_id
+		VALUES (?, ?, ?, ?, ?)
+		)
+	`, c.ID, c.Name, c.Description, c.OwnerId)
+	return err
+}

--- a/services/soso-api/internal/repository/calender.go
+++ b/services/soso-api/internal/repository/calender.go
@@ -45,8 +45,7 @@ func (r *CalenderRepository) Create(ctx context.Context, c *model.Calender) erro
 	_, err := r.DB.ExecContext(ctx, `
 		INSERT INTO calenders (
 			id, name, description, owner_id
-		VALUES (?, ?, ?, ?)
-		)
+		) VALUES (?, ?, ?, ?)
 	`, c.ID, c.Name, c.Description, c.OwnerId)
 	return err
 }

--- a/services/soso-api/internal/validator/calender.go
+++ b/services/soso-api/internal/validator/calender.go
@@ -1,0 +1,10 @@
+package validator
+
+import "github.com/go-playground/validator/v10"
+
+func ResisterCalender(v *validator.Validate) {
+	_ = v.RegisterValidation("name", func(fl validator.FieldLevel) bool {
+		l := len(fl.Field().String())
+		return l < 128
+	})
+}

--- a/services/soso-api/internal/validator/calender.go
+++ b/services/soso-api/internal/validator/calender.go
@@ -7,4 +7,8 @@ func ResisterCalender(v *validator.Validate) {
 		l := len(fl.Field().String())
 		return l < 128
 	})
+	_ = v.RegisterValidation("description", func(fl validator.FieldLevel) bool {
+		l := len(fl.Field().String())
+		return l < 1024
+	})
 }

--- a/services/soso-api/internal/validator/validator.go
+++ b/services/soso-api/internal/validator/validator.go
@@ -9,6 +9,7 @@ func New() *CustomValidator {
 	v := validator.New()
 
 	RegisterUser(v)
+	ResisterCalender(v)
 
 	return &CustomValidator{v: v}
 }

--- a/services/soso-api/tests/internal/handlers/auth_test.go
+++ b/services/soso-api/tests/internal/handlers/auth_test.go
@@ -49,9 +49,9 @@ func TestAuthHandler_Login_OK(t *testing.T) {
 	pwHash, _ := auth.HashPassword("password123")
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
-		"id", "username", "password_hash", "has_car", "capacity", "soso_points", "created_at", "updated_at",
-	}).AddRow("u1", "alice", pwHash, false, 0, 0, now, now)
-	mock.ExpectQuery(SQLSelectUserByName).WithArgs("alice").WillReturnRows(rows)
+		"id", "username", "mail_address", "password_hash", "has_car", "capacity", "created_at", "updated_at",
+	}).AddRow("u1", "alice", "hoge@example.com", pwHash, false, 0, now, now)
+	mock.ExpectQuery(SQLSelectUserByEmailAddress).WithArgs("hoge@example.com").WillReturnRows(rows)
 
 	mock.ExpectExec(SQLInsertRT).
 		WithArgs(sqlmock.AnyArg(), "u1", sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -59,7 +59,7 @@ func TestAuthHandler_Login_OK(t *testing.T) {
 
 	e := NewEcho()
 	req := httptest.NewRequest(http.MethodPost, "/auth/login",
-		bytes.NewBufferString(`{"username":"alice","password":"password123"}`))
+		bytes.NewBufferString(`{"username":"alice","mailAddress":"hoge@example.com","password":"password123"}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -92,13 +92,13 @@ func TestAuthHandler_Login_UserNotFound(t *testing.T) {
 	h, mock, close := newAuthHandler(t)
 	defer close()
 
-	mock.ExpectQuery(SQLSelectUserByName).
-		WithArgs("alice").
+	mock.ExpectQuery(SQLSelectUserByEmailAddress).
+		WithArgs("hoge@example.com").
 		WillReturnRows(sqlmock.NewRows([]string{}))
 
 	e := NewEcho()
 	req := httptest.NewRequest(http.MethodPost, "/auth/login",
-		bytes.NewBufferString(`{"username":"alice","password":"password123"}`))
+		bytes.NewBufferString(`{"username":"alice","mailAddress":"hoge@example.com","password":"password123"}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -117,15 +117,15 @@ func TestAuthHandler_Login_InvalidPassword(t *testing.T) {
 	wrongHash, _ := auth.HashPassword("otherpass")
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
-		"id", "username", "password_hash", "has_car", "capacity", "soso_points", "created_at", "updated_at",
-	}).AddRow("u1", "alice", wrongHash, false, 0, 0, now, now)
-	mock.ExpectQuery(SQLSelectUserByName).
-		WithArgs("alice").
+		"id", "username", "mail_address", "password_hash", "has_car", "capacity", "created_at", "updated_at",
+	}).AddRow("u1", "hoge@example.com", "alice", wrongHash, false, 0, now, now)
+	mock.ExpectQuery(SQLSelectUserByEmailAddress).
+		WithArgs("hoge@example.com").
 		WillReturnRows(rows)
 
 	e := NewEcho()
 	req := httptest.NewRequest(http.MethodPost, "/auth/login",
-		bytes.NewBufferString(`{"username":"alice","password":"password123"}`))
+		bytes.NewBufferString(`{"username":"alice","mailAddress":"hoge@example.com","password":"password123"}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)

--- a/services/soso-api/tests/internal/handlers/calender.go
+++ b/services/soso-api/tests/internal/handlers/calender.go
@@ -1,0 +1,1 @@
+package handlers_test

--- a/services/soso-api/tests/internal/handlers/calender.go
+++ b/services/soso-api/tests/internal/handlers/calender.go
@@ -1,1 +1,0 @@
-package handlers_test

--- a/services/soso-api/tests/internal/handlers/calender_test.go
+++ b/services/soso-api/tests/internal/handlers/calender_test.go
@@ -96,3 +96,21 @@ func TestCalenderCreate_InvalidPayload(t *testing.T) {
 	he := err.(*echo.HTTPError)
 	assert.Equal(t, http.StatusBadRequest, he.Code)
 }
+
+func TestCalenderCreate_Unauthorized(t *testing.T) {
+	dbm := NewSQLMock(t)
+	defer dbm.Close()
+
+	repo := repository.NewCalenderRepository(dbm.DB)
+	h := handlers.NewCalenderHandler(repo)
+	e := NewEcho()
+
+	req := httptest.NewRequest(http.MethodPost, "/calenders/create", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.Create(c)
+	assert.Error(t, err)
+	he := err.(*echo.HTTPError)
+	assert.Equal(t, http.StatusUnauthorized, he.Code)
+}

--- a/services/soso-api/tests/internal/handlers/calender_test.go
+++ b/services/soso-api/tests/internal/handlers/calender_test.go
@@ -7,6 +7,7 @@ import (
 	"soso/internal/handlers"
 	"soso/internal/repository"
 	"testing"
+	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/labstack/echo/v4"
@@ -39,5 +40,37 @@ func TestCalenderCreate_OK(t *testing.T) {
 	err := h.Create(c)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.NoError(t, dbm.Mock.ExpectationsWereMet())
+}
+
+func TestCalenderCreate_Conflict(t *testing.T) {
+	dbm := NewSQLMock(t)
+	defer dbm.Close()
+
+	repo := repository.NewCalenderRepository(dbm.DB)
+	h := handlers.NewCalenderHandler(repo)
+	e := NewEcho()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "name", "description", "owner_id", "created_at", "updated_at",
+	}).AddRow("u1", "jouuhoukyoku", "jouhoukyoku", "u1", now, now)
+
+	dbm.Mock.ExpectQuery(SQLCalenderFindByName).
+		WithArgs("jouhoukyoku").
+		WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodPost, "/calenders/create",
+		bytes.NewBufferString(`{"name":"jouhoukyoku","description":"jouhoukyoku"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	SetJWTUser(c, "u1")
+
+	err := h.Create(c)
+	assert.Error(t, err)
+	he := err.(*echo.HTTPError)
+	assert.Equal(t, http.StatusConflict, he.Code)
 	assert.NoError(t, dbm.Mock.ExpectationsWereMet())
 }

--- a/services/soso-api/tests/internal/handlers/calender_test.go
+++ b/services/soso-api/tests/internal/handlers/calender_test.go
@@ -1,0 +1,43 @@
+package handlers_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"soso/internal/handlers"
+	"soso/internal/repository"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalenderCreate_OK(t *testing.T) {
+	dbm := NewSQLMock(t)
+	defer dbm.Close()
+
+	repo := repository.NewCalenderRepository(dbm.DB)
+	h := handlers.NewCalenderHandler(repo)
+	e := NewEcho()
+
+	dbm.Mock.ExpectQuery(SQLCalenderFindByName).
+		WithArgs("hoge").
+		WillReturnRows(sqlmock.NewRows([]string{}))
+	dbm.Mock.ExpectExec(SQLCalenderCreate).
+		WithArgs(sqlmock.AnyArg(), "jouhoukyoku", "jouhoukyoku", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	req := httptest.NewRequest(http.MethodPost, "/calenders/create",
+		bytes.NewBufferString(`{"name":"jouhoukyoku","description":"jouhoukyoku"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	SetJWTUser(c, "u1")
+
+	err := h.Create(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.NoError(t, dbm.Mock.ExpectationsWereMet())
+}

--- a/services/soso-api/tests/internal/handlers/calender_test.go
+++ b/services/soso-api/tests/internal/handlers/calender_test.go
@@ -74,3 +74,25 @@ func TestCalenderCreate_Conflict(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, he.Code)
 	assert.NoError(t, dbm.Mock.ExpectationsWereMet())
 }
+
+func TestCalenderCreate_InvalidPayload(t *testing.T) {
+	dbm := NewSQLMock(t)
+	defer dbm.Close()
+
+	repo := repository.NewCalenderRepository(dbm.DB)
+	h := handlers.NewCalenderHandler(repo)
+	e := NewEcho()
+
+	req := httptest.NewRequest(http.MethodPost, "/calenders/create",
+		bytes.NewBufferString(`{`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	SetJWTUser(c, "u1")
+
+	err := h.Create(c)
+	assert.Error(t, err)
+	he := err.(*echo.HTTPError)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+}

--- a/services/soso-api/tests/internal/handlers/calender_test.go
+++ b/services/soso-api/tests/internal/handlers/calender_test.go
@@ -22,7 +22,7 @@ func TestCalenderCreate_OK(t *testing.T) {
 	e := NewEcho()
 
 	dbm.Mock.ExpectQuery(SQLCalenderFindByName).
-		WithArgs("hoge").
+		WithArgs("jouhoukyoku").
 		WillReturnRows(sqlmock.NewRows([]string{}))
 	dbm.Mock.ExpectExec(SQLCalenderCreate).
 		WithArgs(sqlmock.AnyArg(), "jouhoukyoku", "jouhoukyoku", sqlmock.AnyArg()).

--- a/services/soso-api/tests/internal/handlers/helpers_test.go
+++ b/services/soso-api/tests/internal/handlers/helpers_test.go
@@ -56,18 +56,33 @@ func Ctx() context.Context { return context.Background() }
 const (
 	SQLInsertUser = `
 		INSERT INTO users (
-			id, username, password_hash, has_car, capacity, soso_points
+			id, username, mail_address, password_hash, has_car, capacity
 		) VALUES (?,?,?,?,?,?)
+	`
+
+	SQLSelectUserByEmailAddress = `
+		SELECT
+			id,
+			username,
+			mail_address,
+			password_hash,
+			has_car,
+			capacity,
+			created_at,
+			updated_at
+		FROM users
+		WHERE mail_address = ?
+		LIMIT 1
 	`
 
 	SQLSelectUserByName = `
 		SELECT
 			id,
 			username,
+			mail_address,
 			password_hash,
 			has_car,
 			capacity,
-			soso_points,
 			created_at,
 			updated_at
 		FROM users
@@ -79,10 +94,10 @@ const (
 		SELECT
 			id,
 			username,
+			mail_address,
 			password_hash,
 			has_car,
 			capacity,
-			soso_points,
 			created_at,
 			updated_at
 		FROM users

--- a/services/soso-api/tests/internal/handlers/helpers_test.go
+++ b/services/soso-api/tests/internal/handlers/helpers_test.go
@@ -132,4 +132,22 @@ const (
 		 WHERE id = ?
 		   AND revoked_at IS NULL
 	`
+	SQLCalenderCreate = `
+		INSERT INTO calenders (
+			id, name, description, owner_id
+		) VALUES (?, ?, ?, ?)
+	`
+
+	SQLCalenderFindByName = `
+		SELECT
+			id,
+			name,
+			description,
+			owner_id,
+			created_at,
+			updated_at
+		FROM calenders
+		WHERE name = ?
+		LIMIT 1
+	`
 )

--- a/services/soso-api/tests/internal/handlers/user_test.go
+++ b/services/soso-api/tests/internal/handlers/user_test.go
@@ -28,13 +28,16 @@ func TestUserHandler_Register_OK(t *testing.T) {
 	dbm.Mock.ExpectQuery(SQLSelectUserByName).
 		WithArgs("alice").
 		WillReturnRows(sqlmock.NewRows([]string{}))
+	dbm.Mock.ExpectQuery(SQLSelectUserByEmailAddress).
+		WithArgs("hoge@example.com").
+		WillReturnRows(sqlmock.NewRows([]string{}))
 	// INSERT
 	dbm.Mock.ExpectExec(SQLInsertUser).
-		WithArgs(sqlmock.AnyArg(), "alice", sqlmock.AnyArg(), false, 0, 0).
+		WithArgs(sqlmock.AnyArg(), "alice", "hoge@example.com", sqlmock.AnyArg(), false, 0).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	req := httptest.NewRequest(http.MethodPost, "/users/register",
-		bytes.NewBufferString(`{"username":"alice","password":"password123"}`))
+		bytes.NewBufferString(`{"username":"alice", "mailAddress":"hoge@example.com", "password":"password123"}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -55,15 +58,15 @@ func TestUserHandler_Register_Conflict(t *testing.T) {
 
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
-		"id", "username", "password_hash", "has_car", "capacity", "soso_points", "created_at", "updated_at",
-	}).AddRow("u1", "alice", "hash", false, 0, 0, now, now)
+		"id", "username", "mail_address", "password_hash", "has_car", "capacity", "created_at", "updated_at",
+	}).AddRow("u1", "alice", "hoge@example.com", "hash", false, 0, now, now)
 
 	dbm.Mock.ExpectQuery(SQLSelectUserByName).
 		WithArgs("alice").
 		WillReturnRows(rows)
 
 	req := httptest.NewRequest(http.MethodPost, "/users/register",
-		bytes.NewBufferString(`{"username":"alice","password":"password123"}`))
+		bytes.NewBufferString(`{"username":"alice", "mailAddress":"hoge@example.com", "password":"password123"}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -103,10 +106,21 @@ func TestUserHandler_Register_CapacityRequired(t *testing.T) {
 	h := handlers.NewUserHandler(repo)
 	e := NewEcho()
 
+	dbm.Mock.ExpectQuery(SQLSelectUserByName).
+		WithArgs("alice").
+		WillReturnRows(sqlmock.NewRows([]string{}))
+	dbm.Mock.ExpectQuery(SQLSelectUserByEmailAddress).
+		WithArgs("hoge@example.com").
+		WillReturnRows(sqlmock.NewRows([]string{}))
+	dbm.Mock.ExpectExec(SQLInsertUser).
+		WithArgs(sqlmock.AnyArg(), "alice", "hoge@example.com", sqlmock.AnyArg(), true, 0).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
 	req := httptest.NewRequest(http.MethodPost, "/users/register",
-		bytes.NewBufferString(`{"username":"bob","password":"password123","has_car":true,"capacity":0}`))
+		bytes.NewBufferString(`{"username":"alice","mailAddress":"hoge@example.com","password":"password123","hasCar":true,"capacity":0}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
+
 	c := e.NewContext(req, rec)
 
 	err := h.Register(c)
@@ -125,8 +139,8 @@ func TestUserHandler_Me_OK(t *testing.T) {
 
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
-		"id", "username", "password_hash", "has_car", "capacity", "soso_points", "created_at", "updated_at",
-	}).AddRow("u1", "alice", "hash", false, 0, 0, now, now)
+		"id", "username", "mail_address", "password_hash", "has_car", "capacity", "created_at", "updated_at",
+	}).AddRow("u1", "alice", "hoge@example.com", "hash", false, 0, now, now)
 
 	dbm.Mock.ExpectQuery(SQLSelectUserByID).
 		WithArgs("u1").

--- a/services/soso-api/tests/internal/repository/calender_test.go
+++ b/services/soso-api/tests/internal/repository/calender_test.go
@@ -3,8 +3,10 @@ package repository_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 
 	"soso/internal/model"
@@ -35,5 +37,63 @@ func TestCalenderRepository_Create_OK(t *testing.T) {
 
 	err := repo.Create(context.Background(), c)
 	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// DB制約エラー
+func TestCalenderRepository_Create_DuplicateCalenderName(t *testing.T) {
+	repo, mock, close := newCalenderRepoMock(t)
+	defer close()
+
+	c := &model.Calender{
+		ID:          "u2",
+		Name:        "jouhoukyoku",
+		Description: "jouhoukyoku",
+		OwnerId:     "u3",
+	}
+
+	mock.ExpectExec(SQLCalenderCreate).
+		WithArgs(c.ID, c.Name, c.Description, c.OwnerId).
+		WillReturnError(&mysql.MySQLError{
+			Number:  1062,
+			Message: "Duplicate entry 'jouhoukyoku' for key 'calenders.name'",
+		})
+
+	err := repo.Create(context.Background(), c)
+	assert.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCalenderRepository_FindByName_Hit(t *testing.T) {
+	repo, mock, close := newCalenderRepoMock(t)
+	defer close()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "name", "descriptions", "owner_id", "created_at", "updated_at",
+	}).AddRow("u1", "jouhoukyoku", "jouhoudescription", "u1", now, now)
+
+	mock.ExpectQuery(SQLCalenderFindByName).
+		WithArgs("jouhoukyoku").
+		WillReturnRows(rows)
+
+	c, err := repo.FindByName(context.Background(), "jouhoukyoku")
+	assert.NoError(t, err)
+	assert.NotNil(t, c)
+	assert.Equal(t, "jouhoukyoku", c.Name)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCalenderRepository_FindByName_NotFound(t *testing.T) {
+	repo, mock, close := newCalenderRepoMock(t)
+	defer close()
+
+	mock.ExpectQuery(SQLCalenderFindByName).
+		WithArgs("jouhoukyoku").
+		WillReturnRows(sqlmock.NewRows([]string{}))
+
+	c, err := repo.FindByName(context.Background(), "jouhoukyoku")
+	assert.NoError(t, err)
+	assert.Nil(t, c)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/services/soso-api/tests/internal/repository/calender_test.go
+++ b/services/soso-api/tests/internal/repository/calender_test.go
@@ -1,0 +1,15 @@
+package repository
+
+import (
+	"soso/internal/repository"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func newCalenderRepoMock(t *testing.T) (*repository.CalenderRepository, sqlmock.Sqlmock, func()) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	assert.NoError(t, err)
+	return repository.NewCalenderRepository(db), mock, func() { _ = db.Close() }
+}

--- a/services/soso-api/tests/internal/repository/calender_test.go
+++ b/services/soso-api/tests/internal/repository/calender_test.go
@@ -1,15 +1,39 @@
-package repository
+package repository_test
 
 import (
-	"soso/internal/repository"
+	"context"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+
+	"soso/internal/model"
+	"soso/internal/repository"
 )
 
 func newCalenderRepoMock(t *testing.T) (*repository.CalenderRepository, sqlmock.Sqlmock, func()) {
 	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	assert.NoError(t, err)
 	return repository.NewCalenderRepository(db), mock, func() { _ = db.Close() }
+}
+
+// Create成功
+func TestCalenderRepository_Create_OK(t *testing.T) {
+	repo, mock, close := newCalenderRepoMock(t)
+	defer close()
+
+	c := &model.Calender{
+		ID:          "u1",
+		Name:        "jouhoukyoku",
+		Description: "jouhoukyoku",
+		OwnerId:     "u2",
+	}
+
+	mock.ExpectExec(SQLCalenderCreate).
+		WithArgs(c.ID, c.Name, c.Description, c.OwnerId).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := repo.Create(context.Background(), c)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/services/soso-api/tests/internal/repository/helpers_test.go
+++ b/services/soso-api/tests/internal/repository/helpers_test.go
@@ -37,7 +37,7 @@ func Ctx() context.Context { return context.Background() }
 const (
 	SQLInsertUser = `
 		INSERT INTO users (
-			id, username, password_hash, has_car, capacity, soso_points
+			id, username, mail_address, password_hash, has_car, capacity
 		) VALUES (?,?,?,?,?,?)
 	`
 
@@ -49,11 +49,25 @@ const (
 			password_hash,
 			has_car,
 			capacity,
-			soso_points,
 			created_at,
 			updated_at
 		FROM users
 		WHERE username = ?
+		LIMIT 1
+	`
+
+	SQLSelectUserByMailAddress = `
+		SELECT
+			id,
+			username,
+			mail_address,
+			password_hash,
+			has_car,
+			capacity,
+			created_at,
+			updated_at
+		FROM users
+		WHERE mail_address = ?
 		LIMIT 1
 	`
 
@@ -65,7 +79,6 @@ const (
 			password_hash,
 			has_car,
 			capacity,
-			soso_points,
 			created_at,
 			updated_at
 		FROM users

--- a/services/soso-api/tests/internal/repository/helpers_test.go
+++ b/services/soso-api/tests/internal/repository/helpers_test.go
@@ -117,8 +117,7 @@ const (
 	SQLCalenderCreate = `
 		INSERT INTO calenders (
 			id, name, description, owner_id
-		VALUES(?, ?, ?, ?)
-		)
+		) VALUES (?, ?, ?, ?)
 	`
 
 	SQLCalenderFindByName = `

--- a/services/soso-api/tests/internal/repository/helpers_test.go
+++ b/services/soso-api/tests/internal/repository/helpers_test.go
@@ -113,4 +113,24 @@ const (
 		 WHERE id = ?
 		   AND revoked_at IS NULL
 	`
+
+	SQLCalenderCreate = `
+		INSERT INTO calenders (
+			id, name, description, owner_id
+		VALUES(?, ?, ?, ?)
+		)
+	`
+
+	SQLCalenderFindByName = `
+		SELECT
+			id,
+			name,
+			description,
+			owner_id,
+			created_at,
+			updated_at
+		FROM calenders
+		WHERE name = ?
+		LIMIT 1
+	`
 )

--- a/services/soso-api/tests/internal/repository/user_test.go
+++ b/services/soso-api/tests/internal/repository/user_test.go
@@ -30,7 +30,7 @@ func TestUserRepository_Create_OK(t *testing.T) {
 
 	u := &model.User{
 		ID:           "u1",
-		MailAddress:  "foo@example.com",
+		MailAddress:  "hoge@example.com",
 		Username:     "alice",
 		PasswordHash: "hash",
 		HasCar:       true,
@@ -74,6 +74,33 @@ func TestUserRepository_Create_DuplicateUsername(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestUserRepository_Create_DuplicateMailAddress(t *testing.T) {
+	repo, mock, close := newUserRepoMock(t)
+	defer close()
+
+	u := &model.User{
+		ID:           "u2",
+		MailAddress:  "hoge@example.com",
+		PasswordHash: "hash2",
+	}
+
+	mock.ExpectExec(SQLInsertUser).
+		WithArgs(u.ID, u.Username, u.MailAddress, u.PasswordHash, u.HasCar, u.Capacity).
+		WillReturnError(&mysql.MySQLError{
+			Number:  1062,
+			Message: "Duplicate entry 'alice' for key 'users.username'",
+		})
+
+	err := repo.Create(context.Background(), u)
+	assert.Error(t, err)
+	// 好みでエラー番号チェック
+	var me *mysql.MySQLError
+	if assert.ErrorAs(t, err, &me) {
+		assert.Equal(t, uint16(1062), me.Number)
+	}
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 // FindByUsername ヒット
 func TestUserRepository_FindByUsername_Hit(t *testing.T) {
 	repo, mock, close := newUserRepoMock(t)
@@ -81,8 +108,8 @@ func TestUserRepository_FindByUsername_Hit(t *testing.T) {
 
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
-		"id", "username", "mail_address", "password_hash", "has_car", "capacity", "soso_points", "created_at", "updated_at",
-	}).AddRow("u1", "alice", "hash", true, 3, 10, now, now)
+		"id", "username", "mail_address", "password_hash", "has_car", "capacity", "created_at", "updated_at",
+	}).AddRow("u1", "alice", "hoge@example.com", "hash", true, 3, now, now)
 
 	mock.ExpectQuery(SQLSelectUserByName).
 		WithArgs("alice").
@@ -92,6 +119,29 @@ func TestUserRepository_FindByUsername_Hit(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, u)
 	assert.Equal(t, "alice", u.Username)
+	assert.True(t, u.HasCar)
+	assert.Equal(t, 3, u.Capacity)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// FindByEmail見つからない
+func TestUserRepository_FindByMailAddress_Hit(t *testing.T) {
+	repo, mock, close := newUserRepoMock(t)
+	defer close()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "username", "mail_address", "password_hash", "has_car", "capacity", "created_at", "updated_at",
+	}).AddRow("u1", "alice", "hoge@example.com", "hash", true, 3, now, now)
+
+	mock.ExpectQuery(SQLSelectUserByMailAddress).
+		WithArgs("hoge@example.com").
+		WillReturnRows(rows)
+
+	u, err := repo.FindByMailAddress(context.Background(), "hoge@example.com")
+	assert.NoError(t, err)
+	assert.NotNil(t, u)
+	assert.Equal(t, "hoge@example.com", u.MailAddress)
 	assert.True(t, u.HasCar)
 	assert.Equal(t, 3, u.Capacity)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -112,6 +162,21 @@ func TestUserRepository_FindByUsername_NotFound(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+// FindByMailAddress 見つからない
+func TestUserRepository_FindByMailAddress_NotFound(t *testing.T) {
+	repo, mock, close := newUserRepoMock(t)
+	defer close()
+
+	mock.ExpectQuery(SQLSelectUserByMailAddress).
+		WithArgs("hogehoge@example.com").
+		WillReturnRows(sqlmock.NewRows([]string{}))
+
+	u, err := repo.FindByMailAddress(context.Background(), "hogehoge@example.com")
+	assert.NoError(t, err)
+	assert.Nil(t, u)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 // FindByID ヒット
 func TestUserRepository_FindByID_Hit(t *testing.T) {
 	repo, mock, close := newUserRepoMock(t)
@@ -119,8 +184,8 @@ func TestUserRepository_FindByID_Hit(t *testing.T) {
 
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
-		"id", "username", "mail_address", "password_hash", "has_car", "capacity", "soso_points", "created_at", "updated_at",
-	}).AddRow("u1", "alice", "hash", false, 0, 0, now, now)
+		"id", "username", "mail_address", "password_hash", "has_car", "capacity", "created_at", "updated_at",
+	}).AddRow("u1", "alice", "hoge@example.com", "hash", false, 0, now, now)
 
 	mock.ExpectQuery(SQLSelectUserByID).
 		WithArgs("u1").


### PR DESCRIPTION
# 概要
- カレンダー追加APi

# やったこと
- カレンダー追加API実装
- カレンダー追加APIのテスト
- ユーザー関係の修正、テストの修正（一緒になっちゃってますすいません）

# 仕様
- JWT認証、CSFTトークン必須
- POSTメソッド
- URI: /calenders/create
## リクエスト
```
{
  "name": "開発チーム",
  "description": "社内配車管理用チーム"
}
```

## レスポンス
`作成成功`
`201`
```
{
  "id": "team_12345",
  "name": "開発チーム",
  "description": "string",
  "ownerId": "usr_12345",
  "createdAt": "2025-08-04T16:22:01.588Z",
  "updatedAt": "2025-08-04T16:22:01.588Z"
}
```
`入力値不正`
`400`
```
{
  "message": "invalid payload"
}
```
`権限不足`
`403`
```
{
  "message": "unauthorized"
}
```
`カレンダー名重複`
`409`
```
{
  "message": "Calender name alread exists"
}
```