### PR TITLE
Feature/kitano/calender-join-api カレンダー参加API

### DIFF
--- a/services/soso-api/internal/config/router.go
+++ b/services/soso-api/internal/config/router.go
@@ -33,6 +33,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	userRepo := &repository.UserRepository{DB: db}
 	rtRepo := &repository.RefreshTokenRepository{DB: db}
 	calRepo := &repository.CalenderRepository{DB: db}
+	calMRepo := &repository.CalenderMembershipRepository{DB: db}
 
 	cookieCfg := handlers.CookieConf{
 		Name:     cfg.CookieNameRT,
@@ -44,6 +45,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	authH := handlers.NewAuthHandler(userRepo, rtRepo, cfg.JWTSigningKey, cfg.AccessTokenTTLMin, cfg.RefreshTokenTTLH, cookieCfg)
 	userH := handlers.NewUserHandler(userRepo)
 	calenderH := handlers.NewCalenderHandler(calRepo)
+	calenderMembershipH := handlers.NewCalenderMembershipHandler(calMRepo)
 
 	// Echo標準ミドルウェア
 	e.Use(echoMW.Logger())
@@ -114,6 +116,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	// Calenders
 	calG := e.Group("/calenders", csrfMW, echojwt.WithConfig(jwtCfg))
 	calG.POST("/create", calenderH.Create)
+	calG.POST("/:calenderId/join", calenderMembershipH.Create)
 
 	// シャットダウン時クローズ
 	e.Server.RegisterOnShutdown(func() { _ = db.Close() })

--- a/services/soso-api/internal/config/router.go
+++ b/services/soso-api/internal/config/router.go
@@ -116,7 +116,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	// Calenders
 	calG := e.Group("/calenders", csrfMW, echojwt.WithConfig(jwtCfg))
 	calG.POST("/create", calenderH.Create)
-	calG.POST("/:calenderId/join", calenderMembershipH.Create)
+	calG.POST("/:calender_id/join", calenderMembershipH.Create)
 
 	// シャットダウン時クローズ
 	e.Server.RegisterOnShutdown(func() { _ = db.Close() })

--- a/services/soso-api/internal/handlers/calender_membership.go
+++ b/services/soso-api/internal/handlers/calender_membership.go
@@ -42,13 +42,32 @@ func (h *CalenderMembershipHandler) Create(c echo.Context) error {
 	}
 	ctx := c.Request().Context()
 
-	if exist, err := h.CalenderMembershipRepo.FindByCalenderIDAndUserID(ctx, req.CalenderID, userId); err != nil {
+	if exist, err := h.CalenderMembershipRepo.FindByCalenderIDAndUserID(ctx, c.Param("calenderId"), userId); err != nil {
 		return err
 	} else if exist != nil {
 		return echo.NewHTTPError(http.StatusConflict, "You already join this calender")
 	}
-	cm := &model.CalenderMembership{
-		CalenderID: req.CalenderID,
-		UserID:     userId,
+	if exist, err := h.CalenderMembershipRepo.FindByCalenderID(ctx, c.Param("calenderId")); err != nil {
+		return err
+	} else if exist != nil {
+		cm := &model.CalenderMembership{
+			CalenderID: c.Param("calenderId"),
+			UserID:     userId,
+			Role:       model.ADMIN,
+		}
+		if err := h.CalenderMembershipRepo.Create(ctx, cm); err != nil {
+			return err
+		}
+		return c.NoContent(http.StatusAccepted)
+	} else {
+		cm := &model.CalenderMembership{
+			CalenderID: c.Param("calenderId"),
+			UserID:     userId,
+			Role:       model.MEMBER,
+		}
+		if err := h.CalenderMembershipRepo.Create(ctx, cm); err != nil {
+			return err
+		}
+		return c.NoContent(http.StatusAccepted)
 	}
 }

--- a/services/soso-api/internal/handlers/calender_membership.go
+++ b/services/soso-api/internal/handlers/calender_membership.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"net/http"
+	"soso/internal/model"
+	"soso/internal/repository"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v4"
+)
+
+type CalenderMembershipHandler struct {
+	CalenderMembershipRepo *repository.CalenderMembershipRepository
+}
+
+func NewCalenderMembershipHandler(r *repository.CalenderMembershipRepository) *CalenderMembershipHandler {
+	return &CalenderMembershipHandler{CalenderMembershipRepo: r}
+}
+
+type CalenderMembershipRequest struct {
+	CalenderID string `json:"calenderId"`
+}
+
+func (h *CalenderMembershipHandler) Create(c echo.Context) error {
+	var req CalenderMembershipRequest
+
+	tok, ok := c.Get("user").(*jwt.Token)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+	}
+	claims, ok := tok.Claims.(*jwt.RegisteredClaims)
+	if !ok || claims.Subject == "" {
+		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+	}
+	userId := claims.Subject
+
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid payload")
+	}
+	if err := c.Validate(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	ctx := c.Request().Context()
+
+	if exist, err := h.CalenderMembershipRepo.FindByCalenderIDAndUserID(ctx, req.CalenderID, userId); err != nil {
+		return err
+	} else if exist != nil {
+		return echo.NewHTTPError(http.StatusConflict, "You already join this calender")
+	}
+	cm := &model.CalenderMembership{
+		CalenderID: req.CalenderID,
+		UserID:     userId,
+	}
+}

--- a/services/soso-api/internal/handlers/calender_membership.go
+++ b/services/soso-api/internal/handlers/calender_membership.go
@@ -18,7 +18,6 @@ func NewCalenderMembershipHandler(r *repository.CalenderMembershipRepository) *C
 }
 
 type CalenderMembershipRequest struct {
-	CalenderID string `json:"calenderId"`
 }
 
 func (h *CalenderMembershipHandler) Create(c echo.Context) error {
@@ -40,34 +39,37 @@ func (h *CalenderMembershipHandler) Create(c echo.Context) error {
 	if err := c.Validate(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
+	if c.Param("calender_id") == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "calender_id is required")
+	}
 	ctx := c.Request().Context()
 
-	if exist, err := h.CalenderMembershipRepo.FindByCalenderIDAndUserID(ctx, c.Param("calenderId"), userId); err != nil {
+	if exist, err := h.CalenderMembershipRepo.FindByCalenderIDAndUserID(ctx, c.Param("calender_id"), userId); err != nil {
 		return err
 	} else if exist != nil {
 		return echo.NewHTTPError(http.StatusConflict, "You already join this calender")
 	}
-	if exist, err := h.CalenderMembershipRepo.FindByCalenderID(ctx, c.Param("calenderId")); err != nil {
+	if exist, err := h.CalenderMembershipRepo.FindByCalenderID(ctx, c.Param("calender_id")); err != nil {
 		return err
-	} else if exist != nil {
+	} else if exist == nil {
 		cm := &model.CalenderMembership{
-			CalenderID: c.Param("calenderId"),
+			CalenderID: c.Param("calender_id"),
 			UserID:     userId,
 			Role:       model.ADMIN,
 		}
 		if err := h.CalenderMembershipRepo.Create(ctx, cm); err != nil {
 			return err
 		}
-		return c.NoContent(http.StatusAccepted)
+		return c.NoContent(http.StatusCreated)
 	} else {
 		cm := &model.CalenderMembership{
-			CalenderID: c.Param("calenderId"),
+			CalenderID: c.Param("calender_id"),
 			UserID:     userId,
 			Role:       model.MEMBER,
 		}
 		if err := h.CalenderMembershipRepo.Create(ctx, cm); err != nil {
 			return err
 		}
-		return c.NoContent(http.StatusAccepted)
+		return c.NoContent(http.StatusCreated)
 	}
 }

--- a/services/soso-api/internal/model/calender_membership.go
+++ b/services/soso-api/internal/model/calender_membership.go
@@ -1,0 +1,18 @@
+package model
+
+import "time"
+
+type Role string
+
+const (
+	ADMIN  Role = "admin"
+	MEMBER Role = "member"
+)
+
+type CalenderMembership struct {
+	CalenderID string `db:"calender_id"`
+	UserID     string `db:"user_id"`
+	Role       Role   `db:"role"`
+	SoSoPoint  int    `db:"soso_point"`
+	JoinedAt   time.Time
+}

--- a/services/soso-api/internal/repository/calender_membership.go
+++ b/services/soso-api/internal/repository/calender_membership.go
@@ -15,6 +15,27 @@ func NewCalenderMembershipRepository(db *sql.DB) *CalenderMembershipRepository {
 	return &CalenderMembershipRepository{DB: db}
 }
 
+func (r *CalenderMembershipRepository) FindByCalenderID(ctx context.Context, calenderID string) (*model.CalenderMembership, error) {
+	row := r.DB.QueryRowContext(ctx, `
+		SELECT
+			*
+		FROM calender_memberships
+		WHERE calender_id = ?
+		LIMIT 1
+	`, calenderID)
+
+	var cm model.CalenderMembership
+	if err := row.Scan(
+		&cm.CalenderID, &cm.UserID, &cm.Role, &cm.SoSoPoint, &cm.JoinedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &cm, nil
+}
+
 func (r *CalenderMembershipRepository) FindByCalenderIDAndUserID(ctx context.Context, calenderId string, userId string) (*model.CalenderMembership, error) {
 	row := r.DB.QueryRowContext(ctx, `
 		SELECT

--- a/services/soso-api/internal/repository/calender_membership.go
+++ b/services/soso-api/internal/repository/calender_membership.go
@@ -1,0 +1,47 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"soso/internal/model"
+)
+
+type CalenderMembershipRepository struct {
+	DB *sql.DB
+}
+
+func NewCalenderMembershipRepository(db *sql.DB) *CalenderMembershipRepository {
+	return &CalenderMembershipRepository{DB: db}
+}
+
+func (r *CalenderMembershipRepository) FindByCalenderIDAndUserID(ctx context.Context, calenderId string, userId string) (*model.CalenderMembership, error) {
+	row := r.DB.QueryRowContext(ctx, `
+		SELECT
+			*
+		FROM calender_memberships
+		WHERE calender_id = ?
+		AND user_id = ?
+		LIMIT 1
+	`, calenderId, userId)
+
+	var cm model.CalenderMembership
+	if err := row.Scan(
+		&cm.CalenderID, &cm.UserID, &cm.Role, &cm.SoSoPoint, &cm.JoinedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &cm, nil
+}
+
+func (r *CalenderMembershipRepository) Create(ctx context.Context, cm *model.CalenderMembership) error {
+	_, err := r.DB.ExecContext(ctx, `
+		INSERT INTO calender_memberships (
+			calender_id, user_id, role
+		) VALUES (?, ?, ?)
+	`, cm.CalenderID, cm.UserID, cm.Role)
+	return err
+}

--- a/services/soso-api/internal/validator/calender_membership.go
+++ b/services/soso-api/internal/validator/calender_membership.go
@@ -1,0 +1,7 @@
+package validator
+
+import "github.com/go-playground/validator/v10"
+
+func ResisterCalenderMembership(v *validator.Validate) {
+
+}

--- a/services/soso-api/tests/internal/handlers/calender_membership_test.go
+++ b/services/soso-api/tests/internal/handlers/calender_membership_test.go
@@ -1,0 +1,49 @@
+package handlers_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"soso/internal/handlers"
+	"soso/internal/repository"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalenderMembershipCreate_OK(t *testing.T) {
+	dbm := NewSQLMock(t)
+	defer dbm.Close()
+
+	repo := repository.NewCalenderMembershipRepository(dbm.DB)
+	h := handlers.NewCalenderMembershipHandler(repo)
+	e := NewEcho()
+
+	dbm.Mock.ExpectQuery(SQLFindByCalenderIDAndUserID).
+		WithArgs("cu1", "uu1").
+		WillReturnRows(sqlmock.NewRows([]string{}))
+	dbm.Mock.ExpectQuery(SQLFindByCalenderID).
+		WithArgs("cu1").
+		WillReturnRows(sqlmock.NewRows([]string{}))
+	dbm.Mock.ExpectExec(SQLCreateCalenderMembership).
+		WithArgs("cu1", "uu1", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	req := httptest.NewRequest(http.MethodPost, "/calenders/cu1/join",
+		bytes.NewBufferString("{}"))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	c.SetParamNames("calender_id")
+	c.SetParamValues("cu1")
+
+	SetJWTUser(c, "uu1")
+
+	err := h.Create(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.NoError(t, dbm.Mock.ExpectationsWereMet())
+}

--- a/services/soso-api/tests/internal/handlers/calender_membership_test.go
+++ b/services/soso-api/tests/internal/handlers/calender_membership_test.go
@@ -7,6 +7,7 @@ import (
 	"soso/internal/handlers"
 	"soso/internal/repository"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/labstack/echo/v4"
@@ -45,5 +46,40 @@ func TestCalenderMembershipCreate_OK(t *testing.T) {
 	err := h.Create(c)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.NoError(t, dbm.Mock.ExpectationsWereMet())
+}
+
+func TestCalenderMembershipCreate_Already(t *testing.T) {
+	dbm := NewSQLMock(t)
+	defer dbm.Close()
+
+	repo := repository.NewCalenderMembershipRepository(dbm.DB)
+	h := handlers.NewCalenderMembershipHandler(repo)
+	e := NewEcho()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"calender_id", "user_id", "role", "soso_point", "joined_at",
+	}).AddRow("cu1", "uu1", "admin", 0, now)
+
+	dbm.Mock.ExpectQuery(SQLFindByCalenderIDAndUserID).
+		WithArgs("cu1", "uu1").
+		WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodPost, "/calenders/cu1/join",
+		bytes.NewBufferString("{}"))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	c.SetParamNames("calender_id")
+	c.SetParamValues("cu1")
+
+	SetJWTUser(c, "uu1")
+
+	err := h.Create(c)
+	assert.Error(t, err)
+	he := err.(*echo.HTTPError)
+	assert.Equal(t, http.StatusConflict, he.Code)
 	assert.NoError(t, dbm.Mock.ExpectationsWereMet())
 }

--- a/services/soso-api/tests/internal/handlers/helpers_test.go
+++ b/services/soso-api/tests/internal/handlers/helpers_test.go
@@ -150,4 +150,27 @@ const (
 		WHERE name = ?
 		LIMIT 1
 	`
+
+	SQLFindByCalenderIDAndUserID = `
+		SELECT
+			*
+		FROM calender_memberships
+		WHERE calender_id = ?
+		AND user_id = ?
+		LIMIT 1
+	`
+
+	SQLCreateCalenderMembership = `
+		INSERT INTO calender_memberships (
+			calender_id, user_id, role
+		) VALUES (?, ?, ?)
+	`
+
+	SQLFindByCalenderID = `
+		SELECT
+			*
+		FROM calender_memberships
+		WHERE calender_id = ?
+		LIMIT 1
+	`
 )

--- a/services/soso-api/tests/internal/repository/calender_membership_test.go
+++ b/services/soso-api/tests/internal/repository/calender_membership_test.go
@@ -1,0 +1,1 @@
+package repository_test

--- a/services/soso-api/tests/internal/repository/calender_membership_test.go
+++ b/services/soso-api/tests/internal/repository/calender_membership_test.go
@@ -1,1 +1,59 @@
 package repository_test
+
+import (
+	"context"
+	"soso/internal/model"
+	"soso/internal/repository"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func newCalenderMembershipRepoMock(t *testing.T) (*repository.CalenderMembershipRepository, sqlmock.Sqlmock, func()) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	assert.NoError(t, err)
+	return repository.NewCalenderMembershipRepository(db), mock, func() { _ = db.Close() }
+}
+
+// Create 成功
+func TestCalenderMembershipRepository_Create_OK(t *testing.T) {
+	repo, mock, close := newCalenderMembershipRepoMock(t)
+	defer close()
+
+	cm := &model.CalenderMembership{
+		CalenderID: "cu1",
+		UserID:     "uu1",
+		Role:       model.ADMIN,
+	}
+
+	mock.ExpectExec(SQLCreateCalenderMembership).
+		WithArgs(cm.CalenderID, cm.UserID, cm.Role).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := repo.Create(context.Background(), cm)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCalenderMembershipRepository_FindByCalenderIDAndUserID(t *testing.T) {
+	repo, mock, close := newCalenderMembershipRepoMock(t)
+	defer close()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"calender_id", "user_id", "role", "soso_point", "joind_at",
+	}).AddRow("cu1", "uu1", "admin", 0, now)
+
+	mock.ExpectQuery(SQLFindByCalenderIDAndUserID).
+		WithArgs("cu1", "uu1").
+		WillReturnRows(rows)
+
+	c, err := repo.FindByCalenderIDAndUserID(context.Background(), "cu1", "uu1")
+	assert.NoError(t, err)
+	assert.NotNil(t, c)
+	assert.Equal(t, "cu1", c.CalenderID)
+	assert.Equal(t, "uu1", c.UserID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/services/soso-api/tests/internal/repository/calender_membership_test.go
+++ b/services/soso-api/tests/internal/repository/calender_membership_test.go
@@ -57,3 +57,23 @@ func TestCalenderMembershipRepository_FindByCalenderIDAndUserID(t *testing.T) {
 	assert.Equal(t, "uu1", c.UserID)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestCalenderMembershipRepository_FindByCalenderID_OK(t *testing.T) {
+	repo, mock, close := newCalenderMembershipRepoMock(t)
+	defer close()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"calender_id", "user_id", "role", "soso_point", "joind_at",
+	}).AddRow("cu1", "uu1", "admin", 0, now)
+
+	mock.ExpectQuery(SQLFindByCalenderID).
+		WithArgs("cu1").
+		WillReturnRows(rows)
+
+	c, err := repo.FindByCalenderID(context.Background(), "cu1")
+	assert.NoError(t, err)
+	assert.NotNil(t, c)
+	assert.Equal(t, "cu1", c.CalenderID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/services/soso-api/tests/internal/repository/helpers_test.go
+++ b/services/soso-api/tests/internal/repository/helpers_test.go
@@ -147,4 +147,12 @@ const (
 			calender_id, user_id, role
 		) VALUES (?, ?, ?)
 	`
+
+	SQLFindByCalenderID = `
+		SELECT
+			*
+		FROM calender_memberships
+		WHERE calender_id = ?
+		LIMIT 1
+	`
 )

--- a/services/soso-api/tests/internal/repository/helpers_test.go
+++ b/services/soso-api/tests/internal/repository/helpers_test.go
@@ -132,4 +132,19 @@ const (
 		WHERE name = ?
 		LIMIT 1
 	`
+
+	SQLFindByCalenderIDAndUserID = `
+		SELECT
+			*
+		FROM calender_memberships
+		WHERE calender_id = ?
+		AND user_id = ?
+		LIMIT 1
+	`
+
+	SQLCreateCalenderMembership = `
+		INSERT INTO calender_memberships (
+			calender_id, user_id, role
+		) VALUES (?, ?, ?)
+	`
 )


### PR DESCRIPTION
# 概要
- カレンダー参加API

# やったこと
- カレンダー参加API実装
- カレンダー追加APIのテスト

# 仕様
- JWT認証、CSRFトークン必須
- POSTメソッド
- URI: /calenders/{calender_id}/join
- 初期参加の人はADMINロールがつく

## リクエスト
```
{}
```

## レスポンス
参加成功
`201`
```
{}
```
## 権限不足
`403`
```
{
  "message": "unauthorized"
}
```

## すでに参加してる
`409`
```
{
  "message": "you already join this calender"
}
```