### PR TITLE
Feature/kitano/calender-my-api 自身が所属するカレンダー一覧取得API

### DIFF
--- a/services/soso-api/api/swagger.yaml
+++ b/services/soso-api/api/swagger.yaml
@@ -304,7 +304,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /calenders/list:
+  /calenders/list/me:
     get:
       tags: [Calenders]
       summary: カレンダー一覧取得

--- a/services/soso-api/api/swagger.yaml
+++ b/services/soso-api/api/swagger.yaml
@@ -304,7 +304,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /calenders/list/me:
+  /calenders/mylist/:
     get:
       tags: [Calenders]
       summary: カレンダー一覧取得

--- a/services/soso-api/api/swagger.yaml
+++ b/services/soso-api/api/swagger.yaml
@@ -304,7 +304,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /calenders/mylist/:
+  /calenders/my/:
     get:
       tags: [Calenders]
       summary: カレンダー一覧取得

--- a/services/soso-api/internal/config/router.go
+++ b/services/soso-api/internal/config/router.go
@@ -117,6 +117,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	calG := e.Group("/calenders", csrfMW, echojwt.WithConfig(jwtCfg))
 	calG.POST("/create", calenderH.Create)
 	calG.POST("/:calender_id/join", calenderMembershipH.Create)
+	calG.GET("/mylist", calenderH.FindMyCalenders)
 
 	// シャットダウン時クローズ
 	e.Server.RegisterOnShutdown(func() { _ = db.Close() })

--- a/services/soso-api/internal/config/router.go
+++ b/services/soso-api/internal/config/router.go
@@ -117,7 +117,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	calG := e.Group("/calenders", csrfMW, echojwt.WithConfig(jwtCfg))
 	calG.POST("/create", calenderH.Create)
 	calG.POST("/:calender_id/join", calenderMembershipH.Create)
-	calG.GET("/mylist", calenderH.FindMyCalenders)
+	calG.GET("/my", calenderH.FindMyCalenders)
 
 	// シャットダウン時クローズ
 	e.Server.RegisterOnShutdown(func() { _ = db.Close() })

--- a/services/soso-api/internal/handlers/calender.go
+++ b/services/soso-api/internal/handlers/calender.go
@@ -23,6 +23,35 @@ type CalenderCreateRequest struct {
 	Description string `json:"description" validate:"description"`
 }
 
+func (h *CalenderHandler) FindMyCalenders(c echo.Context) error {
+	tok, ok := c.Get("user").(*jwt.Token)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+	}
+	claims, ok := tok.Claims.(*jwt.RegisteredClaims)
+	if !ok || claims.Subject == "" {
+		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+	}
+	userID := claims.Subject
+
+	ctx := c.Request().Context()
+	cals, err := h.CalenderRepo.FindCalendersByUserId(ctx, userID)
+	if err != nil {
+		return err
+	}
+
+	resp := make([]map[string]any, len(cals))
+	for i, ca := range cals {
+		resp[i] = map[string]any{
+			"id":          ca.ID,
+			"name":        ca.Name,
+			"description": ca.Description,
+			"ownerId":     ca.OwnerId,
+		}
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
 func (h *CalenderHandler) Create(c echo.Context) error {
 	var req CalenderCreateRequest
 

--- a/services/soso-api/internal/repository/calender.go
+++ b/services/soso-api/internal/repository/calender.go
@@ -15,6 +15,44 @@ func NewCalenderRepository(db *sql.DB) *CalenderRepository {
 	return &CalenderRepository{DB: db}
 }
 
+func (r *CalenderRepository) FindCalendersByUserId(ctx context.Context, userID string) ([]*model.Calender, error) {
+	rows, err := r.DB.QueryContext(ctx, `
+		SELECT
+			c.id	AS id,
+			c.name	AS name,
+			c.description AS description,
+			c.owner_id AS owner_id,
+		FROM
+			calender_memberships AS cm
+			INNER JOIN calenders AS c
+				ON c.id = cm.calender_id
+		WHERE
+			cm.user_id = ?
+	`, userID)
+
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var list []*model.Calender
+	for rows.Next() {
+		var cal model.Calender
+		var desc sql.NullString
+		if err := rows.Scan(
+			&cal.ID, &cal.Name, &desc, &cal.OwnerId,
+		); err != nil {
+			return nil, err
+		}
+		cal.Description = desc.String
+		list = append(list, &cal)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
 func (r *CalenderRepository) FindByName(ctx context.Context, name string) (*model.Calender, error) {
 	row := r.DB.QueryRowContext(ctx, `
 		SELECT

--- a/services/soso-api/tests/internal/handlers/calender_test.go
+++ b/services/soso-api/tests/internal/handlers/calender_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"soso/internal/handlers"
@@ -13,6 +14,43 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestCalenderFindMyCalenders_OK(t *testing.T) {
+	dbm := NewSQLMock(t)
+	defer dbm.Close()
+
+	repo := repository.NewCalenderRepository(dbm.DB)
+	h := handlers.NewCalenderHandler(repo)
+	e := NewEcho()
+
+	rows := sqlmock.NewRows([]string{
+		"id", "name", "description", "owner_id",
+	}).AddRow("cal1", "Calendar 1", "desc1", "u1").
+		AddRow("cal2", "Calendar 2", "desc2", "u1")
+
+	dbm.Mock.ExpectQuery(SQLFindCalendersByUserID).
+		WithArgs("u1").
+		WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodGet, "/calenders/my", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	SetJWTUser(c, "u1")
+
+	err := h.FindMyCalenders(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// レスポンスが JSON 配列で 2 要素あるか確認
+	var got []map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Len(t, got, 2)
+	assert.Equal(t, "cal1", got[0]["id"])
+	assert.Equal(t, "Calendar 2", got[1]["name"])
+
+	assert.NoError(t, dbm.Mock.ExpectationsWereMet())
+}
 
 func TestCalenderCreate_OK(t *testing.T) {
 	dbm := NewSQLMock(t)

--- a/services/soso-api/tests/internal/handlers/helpers_test.go
+++ b/services/soso-api/tests/internal/handlers/helpers_test.go
@@ -173,4 +173,18 @@ const (
 		WHERE calender_id = ?
 		LIMIT 1
 	`
+
+	SQLFindCalendersByUserID = `
+		SELECT
+			c.id	AS id,
+			c.name	AS name,
+			c.description AS description,
+			c.owner_id AS owner_id,
+		FROM
+			calender_memberships AS cm
+			INNER JOIN calenders AS c
+				ON c.id = cm.calender_id
+		WHERE
+			cm.user_id = ?
+	`
 )

--- a/services/soso-api/tests/internal/repository/calender_test.go
+++ b/services/soso-api/tests/internal/repository/calender_test.go
@@ -97,3 +97,42 @@ func TestCalenderRepository_FindByName_NotFound(t *testing.T) {
 	assert.Nil(t, c)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestCalenderRepository_FindCalendersByUserId_Hit(t *testing.T) {
+	repo, mock, close := newCalenderRepoMock(t)
+	defer close()
+
+	rows := sqlmock.NewRows([]string{
+		"id", "name", "description", "owner_id",
+	}).AddRow("cal1", "Calendar 1", "desc1", "u1").
+		AddRow("cal2", "Calendar 2", "desc2", "u1")
+
+	mock.ExpectQuery(SQLFindCalendersByUserID).
+		WithArgs("u1").
+		WillReturnRows(rows)
+
+	list, err := repo.FindCalendersByUserId(context.Background(), "u1")
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+	assert.Equal(t, "cal1", list[0].ID)
+	assert.Equal(t, "Calendar 2", list[1].Name)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCalenderRepository_FindCalendersByUserId_NotFound(t *testing.T) {
+	repo, mock, close := newCalenderRepoMock(t)
+	defer close()
+
+	emptyRows := sqlmock.NewRows([]string{
+		"id", "name", "description", "owner_id",
+	}) // カラムは必要。行は追加しない。
+
+	mock.ExpectQuery(SQLFindCalendersByUserID).
+		WithArgs("u1").
+		WillReturnRows(emptyRows)
+
+	list, err := repo.FindCalendersByUserId(context.Background(), "u1")
+	assert.NoError(t, err)
+	assert.Len(t, list, 0)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/services/soso-api/tests/internal/repository/helpers_test.go
+++ b/services/soso-api/tests/internal/repository/helpers_test.go
@@ -155,4 +155,17 @@ const (
 		WHERE calender_id = ?
 		LIMIT 1
 	`
+	SQLFindCalendersByUserID = `
+		SELECT
+			c.id	AS id,
+			c.name	AS name,
+			c.description AS description,
+			c.owner_id AS owner_id,
+		FROM
+			calender_memberships AS cm
+			INNER JOIN calenders AS c
+				ON c.id = cm.calender_id
+		WHERE
+			cm.user_id = ?
+	`
 )


### PR DESCRIPTION
# 概要
- 自身が所属するカレンダー一覧取得API

# やったこと
- 自身が所属するカレンダー一覧取得APIの実装とテスト

# 仕様
- JWT認証、CSRFトークン必須
- GETメソッド
- URI:/calenders/my

## リクエスト
`{}`

## レスポンス
### 取得成功
`200`
```
{
　"id":"282918239399"
　"name": "情報局"
　"description":"44th NUTMEG"
    "ownderId":"29837239837"
}
```
### 権限不足
`403`
```
{
  "message": "unauthorized"
}
```