### PR TITLE
Feature/kitano/get calender members api 自身が所属するカレンダーのメンバー一覧取得

### DIFF
--- a/services/soso-api/go.mod
+++ b/services/soso-api/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/services/soso-api/go.sum
+++ b/services/soso-api/go.sum
@@ -21,6 +21,8 @@ github.com/golang-jwt/jwt/v5 v5.2.3/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVI
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
+github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
+github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
 github.com/labstack/echo-jwt/v4 v4.3.1 h1:d8+/qf8nx7RxeL46LtoIwHJsH2PNN8xXCQ/jDianycE=
 github.com/labstack/echo-jwt/v4 v4.3.1/go.mod h1:yJi83kN8S/5vePVPd+7ID75P4PqPNVRs2HVeuvYJH00=
 github.com/labstack/echo/v4 v4.13.4 h1:oTZZW+T3s9gAu5L8vmzihV7/lkXGZuITzTQkTEhcXEA=

--- a/services/soso-api/internal/config/router.go
+++ b/services/soso-api/internal/config/router.go
@@ -118,6 +118,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	calG.POST("/create", calenderH.Create)
 	calG.POST("/:calender_id/join", calenderMembershipH.Create)
 	calG.GET("/my", calenderH.FindMyCalenders)
+	calG.GET("/:calender_id/members", calenderMembershipH.MemberList)
 
 	// シャットダウン時クローズ
 	e.Server.RegisterOnShutdown(func() { _ = db.Close() })

--- a/services/soso-api/internal/config/router.go
+++ b/services/soso-api/internal/config/router.go
@@ -118,7 +118,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	calG.POST("/create", calenderH.Create)
 	calG.POST("/:calender_id/join", calenderMembershipH.Create)
 	calG.GET("/my", calenderH.FindMyCalenders)
-	calG.GET("/:calender_id/members", calenderMembershipH.MemberList)
+	calG.GET("/:calender_id/members", calenderMembershipH.List)
 
 	// シャットダウン時クローズ
 	e.Server.RegisterOnShutdown(func() { _ = db.Close() })

--- a/services/soso-api/internal/handlers/calender_membership.go
+++ b/services/soso-api/internal/handlers/calender_membership.go
@@ -9,6 +9,14 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+type CalenderMemberResponse struct {
+	UserID    string `json:"userId"`
+	Username  string `json:"username"`
+	HasCar    bool   `json:"hasCar"`
+	Capacity  int    `json:"capacity"`
+	SoSoPoint int    `json:"sosoPoint"`
+}
+
 type CalenderMembershipHandler struct {
 	CalenderMembershipRepo *repository.CalenderMembershipRepository
 }
@@ -18,6 +26,51 @@ func NewCalenderMembershipHandler(r *repository.CalenderMembershipRepository) *C
 }
 
 type CalenderMembershipRequest struct {
+}
+
+func (h *CalenderMembershipHandler) MemberList(c echo.Context) error {
+	tok, ok := c.Get("user").(*jwt.Token)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+	}
+	claims, ok := tok.Claims.(*jwt.RegisteredClaims)
+	if !ok || claims.Subject == "" {
+		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+	}
+	userID := claims.Subject
+
+	calenderID := c.Param("calender_id")
+	if calenderID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "calender_id is required")
+	}
+
+	ctx := c.Request().Context()
+
+	member, err := h.CalenderMembershipRepo.FindByCalenderIDAndUserID(ctx, calenderID, userID)
+	if err != nil {
+		return err
+	}
+	if member == nil {
+		return echo.NewHTTPError(http.StatusForbidden, "forbidden")
+	}
+
+	members, err := h.CalenderMembershipRepo.FindMembersByCalenderID(ctx, calenderID)
+	if err != nil {
+		return err
+	}
+
+	res := make([]*CalenderMemberResponse, 0, len(members))
+	for _, m := range members {
+		res = append(res, &CalenderMemberResponse{
+			UserID:    m.UserID,
+			Username:  m.Username,
+			HasCar:    m.HasCar,
+			Capacity:  m.Capacity,
+			SoSoPoint: m.SoSoPoint,
+		})
+	}
+
+	return c.JSON(http.StatusOK, res)
 }
 
 func (h *CalenderMembershipHandler) Create(c echo.Context) error {

--- a/services/soso-api/internal/handlers/calender_membership.go
+++ b/services/soso-api/internal/handlers/calender_membership.go
@@ -9,14 +9,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type CalenderMemberResponse struct {
-	UserID    string `json:"userId"`
-	Username  string `json:"username"`
-	HasCar    bool   `json:"hasCar"`
-	Capacity  int    `json:"capacity"`
-	SoSoPoint int    `json:"sosoPoint"`
-}
-
 type CalenderMembershipHandler struct {
 	CalenderMembershipRepo *repository.CalenderMembershipRepository
 }
@@ -28,7 +20,18 @@ func NewCalenderMembershipHandler(r *repository.CalenderMembershipRepository) *C
 type CalenderMembershipRequest struct {
 }
 
-func (h *CalenderMembershipHandler) MemberList(c echo.Context) error {
+// DTO (JSON のキーは camelCase)
+type CalenderMemberResponse struct {
+	UserID    string `json:"userId"`
+	Username  string `json:"username"`
+	HasCar    bool   `json:"hasCar"`
+	Capacity  int    `json:"capacity"`
+	SoSoPoint int    `json:"sosoPoint"`
+}
+
+// GET /calenders/:calender_id/members
+func (h *CalenderMembershipHandler) List(c echo.Context) error {
+	// --- 認証 -------------------------------------------------------------
 	tok, ok := c.Get("user").(*jwt.Token)
 	if !ok {
 		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
@@ -39,6 +42,7 @@ func (h *CalenderMembershipHandler) MemberList(c echo.Context) error {
 	}
 	userID := claims.Subject
 
+	// --- パスパラメータ -----------------------------------------------------
 	calenderID := c.Param("calender_id")
 	if calenderID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "calender_id is required")
@@ -46,6 +50,7 @@ func (h *CalenderMembershipHandler) MemberList(c echo.Context) error {
 
 	ctx := c.Request().Context()
 
+	// --- 所属チェック -------------------------------------------------------
 	member, err := h.CalenderMembershipRepo.FindByCalenderIDAndUserID(ctx, calenderID, userID)
 	if err != nil {
 		return err
@@ -54,14 +59,16 @@ func (h *CalenderMembershipHandler) MemberList(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusForbidden, "forbidden")
 	}
 
+	// --- 一覧取得 -----------------------------------------------------------
 	members, err := h.CalenderMembershipRepo.FindMembersByCalenderID(ctx, calenderID)
 	if err != nil {
 		return err
 	}
 
-	res := make([]*CalenderMemberResponse, 0, len(members))
+	// --- DTO 変換 -----------------------------------------------------------
+	resp := make([]*CalenderMemberResponse, 0, len(members))
 	for _, m := range members {
-		res = append(res, &CalenderMemberResponse{
+		resp = append(resp, &CalenderMemberResponse{
 			UserID:    m.UserID,
 			Username:  m.Username,
 			HasCar:    m.HasCar,
@@ -70,7 +77,7 @@ func (h *CalenderMembershipHandler) MemberList(c echo.Context) error {
 		})
 	}
 
-	return c.JSON(http.StatusOK, res)
+	return c.JSON(http.StatusOK, resp)
 }
 
 func (h *CalenderMembershipHandler) Create(c echo.Context) error {

--- a/services/soso-api/internal/model/calender_member.go
+++ b/services/soso-api/internal/model/calender_member.go
@@ -1,0 +1,9 @@
+package model
+
+type CalenderMember struct {
+	UserID    string `db:"user_id"`
+	Username  string `db:"username"`
+	HasCar    bool   `db:"has_car"`
+	Capacity  int    `db:"capacity"`
+	SoSoPoint int    `db:"soso_point"`
+}

--- a/services/soso-api/internal/repository/calender_membership.go
+++ b/services/soso-api/internal/repository/calender_membership.go
@@ -15,6 +15,49 @@ func NewCalenderMembershipRepository(db *sql.DB) *CalenderMembershipRepository {
 	return &CalenderMembershipRepository{DB: db}
 }
 
+func (r *CalenderMembershipRepository) FindMembersByCalenderID(
+	ctx context.Context,
+	calenderID string,
+) ([]*model.CalenderMember, error) {
+
+	rows, err := r.DB.QueryContext(ctx, `
+		SELECT
+			cm.user_id,
+			u.username,
+			u.has_car,
+			u.capacity,
+			cm.soso_point
+		FROM calender_memberships AS cm
+		INNER JOIN users AS u ON u.id = cm.user_id
+		WHERE cm.calender_id = ?
+	`, calenderID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	members := make([]*model.CalenderMember, 0)
+	for rows.Next() {
+		var m model.CalenderMember
+		if err := rows.Scan(
+			&m.UserID,
+			&m.Username,
+			&m.HasCar,
+			&m.Capacity,
+			&m.SoSoPoint,
+		); err != nil {
+			return nil, err
+		}
+		members = append(members, &m)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return members, nil
+}
+
 func (r *CalenderMembershipRepository) FindByCalenderID(ctx context.Context, calenderID string) (*model.CalenderMembership, error) {
 	row := r.DB.QueryRowContext(ctx, `
 		SELECT

--- a/services/soso-api/tests/internal/handlers/calender_membership_test.go
+++ b/services/soso-api/tests/internal/handlers/calender_membership_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"soso/internal/handlers"
@@ -13,6 +14,86 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
+
+func newHandlerWithMock(t *testing.T) (*handlers.CalenderMembershipHandler, sqlmock.Sqlmock, func()) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	assert.NoError(t, err)
+
+	repo := repository.NewCalenderMembershipRepository(db)
+	h := handlers.NewCalenderMembershipHandler(repo)
+
+	return h, mock, func() { _ = db.Close() }
+}
+
+func TestCalenderMembershipList_OK(t *testing.T) {
+	h, mock, closeFn := newHandlerWithMock(t)
+	defer closeFn()
+
+	calID := "cu1"
+	userID := "uu1"
+	now := time.Now()
+
+	mock.ExpectQuery(`SELECT\s+\*\s+FROM calender_memberships`).
+		WithArgs(calID, userID).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"calender_id", "user_id", "role", "soso_point", "joined_at",
+		}).AddRow(calID, userID, "member", 0, now))
+
+	mock.ExpectQuery(`SELECT\s+cm\.user_id`).
+		WithArgs(calID).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"user_id", "username", "has_car", "capacity", "soso_point",
+		}).AddRow("uu1", "alice", true, 4, 10).
+			AddRow("uu2", "bob", false, 2, 3))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/calenders/"+calID+"/members", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("calender_id")
+	c.SetParamValues(calID)
+	SetJWTUser(c, userID)
+
+	err := h.List(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var got []handlers.CalenderMemberResponse
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Len(t, got, 2)
+	assert.Equal(t, "uu1", got[0].UserID)
+	assert.Equal(t, "alice", got[0].Username)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCalenderMembershipList_Forbidden(t *testing.T) {
+	h, mock, closeFn := newHandlerWithMock(t)
+	defer closeFn()
+
+	calID := "cu1"
+	userID := "uuX"
+
+	mock.ExpectQuery(`SELECT\s+\*\s+FROM calender_memberships`).
+		WithArgs(calID, userID).
+		WillReturnRows(sqlmock.NewRows([]string{}))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/calenders/"+calID+"/members", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("calender_id")
+	c.SetParamValues(calID)
+	SetJWTUser(c, userID)
+
+	err := h.List(c)
+	assert.Error(t, err)
+	he, ok := err.(*echo.HTTPError)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusForbidden, he.Code)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
 
 func TestCalenderMembershipCreate_OK(t *testing.T) {
 	dbm := NewSQLMock(t)

--- a/services/soso-api/tests/internal/handlers/helpers_test.go
+++ b/services/soso-api/tests/internal/handlers/helpers_test.go
@@ -187,4 +187,15 @@ const (
 		WHERE
 			cm.user_id = ?
 	`
+	SQLFindMembersByCalenderID = `
+		SELECT
+				cm.user_id,
+				u.username,
+				u.has_car,
+				u.capacity,
+				cm.soso_point
+		FROM calender_memberships AS cm
+		INNER JOIN users AS u ON u.id = cm.user_id
+		WHERE cm.calender_id = ?
+	`
 )

--- a/services/soso-api/tests/internal/repository/calender_membership_test.go
+++ b/services/soso-api/tests/internal/repository/calender_membership_test.go
@@ -77,3 +77,42 @@ func TestCalenderMembershipRepository_FindByCalenderID_OK(t *testing.T) {
 	assert.Equal(t, "cu1", c.CalenderID)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestCalenderMembershipRepository_FindMembersByCalenderID_OK(t *testing.T) {
+	repo, mock, close := newCalenderMembershipRepoMock(t)
+	defer close()
+
+	calenderID := "cu1"
+	rows := sqlmock.NewRows([]string{
+		"user_id", "username", "has_car", "capacity", "soso_point",
+	}).
+		AddRow("uu1", "alice", 1, 4, 10).
+		AddRow("uu2", "bob", 0, 2, 3)
+
+	mock.ExpectQuery(SQLFindMembersByCalenderID).
+		WithArgs(calenderID).
+		WillReturnRows(rows)
+
+	members, err := repo.FindMembersByCalenderID(context.Background(), calenderID)
+	assert.NoError(t, err)
+	assert.Len(t, members, 2)
+
+	want0 := &model.CalenderMember{
+		UserID:    "uu1",
+		Username:  "alice",
+		HasCar:    true,
+		Capacity:  4,
+		SoSoPoint: 10,
+	}
+	want1 := &model.CalenderMember{
+		UserID:    "uu2",
+		Username:  "bob",
+		HasCar:    false,
+		Capacity:  2,
+		SoSoPoint: 3,
+	}
+
+	assert.Equal(t, want0, members[0])
+	assert.Equal(t, want1, members[1])
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/services/soso-api/tests/internal/repository/helpers_test.go
+++ b/services/soso-api/tests/internal/repository/helpers_test.go
@@ -168,4 +168,15 @@ const (
 		WHERE
 			cm.user_id = ?
 	`
+	SQLFindMembersByCalenderID = `
+		SELECT
+			cm.user_id,
+			u.username,
+			u.has_car,
+			u.capacity,
+			cm.soso_point
+		FROM calender_memberships AS cm
+		INNER JOIN users AS u ON u.id = cm.user_id
+		WHERE cm.calender_id = ?
+	`
 )


### PR DESCRIPTION
# 概要
- 自身が所属するカレンダのメンバー一覧取得API

# やったこと
- 自身が所属するカレンダのメンバー一覧取得APIの実装とテスト

# 仕様
- JWT認証、CSRFトークン必須
- GETメソッド
- URI: /calenders/{calender_id}/members

## リクエスト
```
{}
```

## レスポンス
### 取得成功
`200`
```
{
  "userId": "2893829383292"
  "userName":"masaki.kitano"
  "hasCar":"true"
  "capacity":"4"
  "sosoPoint":"10"
}
```

### パラメータ不正
`400`
```
{
  "message": "calender_id is required"
}
```

### 権限不足
`403`
```
{
  "message": "unauthorized"
}
```

### カレンダーに参加してない
`403`
```
{
  "message": "forbidden"
}
```