### PR TITLE
Feature/kitano/events resister api Event関連追加・一覧取得・取得APIの実装

### DIFF
--- a/services/soso-api/api/swagger.yaml
+++ b/services/soso-api/api/swagger.yaml
@@ -469,7 +469,7 @@ paths:
   /calenders/{calenderId}/events:
     get:
       tags: [events]
-      summary: 配車希望一覧取得
+      summary: 配車希望一覧取得（実装済み）
       operationId: listevents
       security:
         - AccessToken: []
@@ -506,7 +506,7 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
     post:
       tags: [events]
-      summary: 配車希望登録
+      summary: 配車希望登録(実装済み)
       operationId: createevent
       security:
         - AccessToken: []
@@ -540,7 +540,7 @@ paths:
   /events/{eventId}:
     get:
       tags: [events]
-      summary: 配車希望取得
+      summary: 配車希望取得(実装済み)
       operationId: getevent
       security:
         - AccessToken: []

--- a/services/soso-api/internal/config/router.go
+++ b/services/soso-api/internal/config/router.go
@@ -124,6 +124,9 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	calG.POST(":calender_id/events", eventH.Create)
 	calG.GET(":calender_id/events", eventH.ListByCalender)
 
+	eveG := e.Group("/events", csrfMW, echojwt.WithConfig(jwtCfg))
+	eveG.GET(":eventId", eventH.FindById)
+
 	// シャットダウン時クローズ
 	e.Server.RegisterOnShutdown(func() { _ = db.Close() })
 	return e

--- a/services/soso-api/internal/config/router.go
+++ b/services/soso-api/internal/config/router.go
@@ -34,6 +34,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	rtRepo := &repository.RefreshTokenRepository{DB: db}
 	calRepo := &repository.CalenderRepository{DB: db}
 	calMRepo := &repository.CalenderMembershipRepository{DB: db}
+	eveRepo := &repository.EventRepository{DB: db}
 
 	cookieCfg := handlers.CookieConf{
 		Name:     cfg.CookieNameRT,
@@ -46,6 +47,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	userH := handlers.NewUserHandler(userRepo)
 	calenderH := handlers.NewCalenderHandler(calRepo)
 	calenderMembershipH := handlers.NewCalenderMembershipHandler(calMRepo)
+	eventH := handlers.NewEventHandler(eveRepo)
 
 	// Echo標準ミドルウェア
 	e.Use(echoMW.Logger())
@@ -119,6 +121,8 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	calG.POST("/:calender_id/join", calenderMembershipH.Create)
 	calG.GET("/my", calenderH.FindMyCalenders)
 	calG.GET("/:calender_id/members", calenderMembershipH.List)
+	calG.POST(":calender_id/events", eventH.Create)
+	calG.GET(":calender_id/events", eventH.ListByCalender)
 
 	// シャットダウン時クローズ
 	e.Server.RegisterOnShutdown(func() { _ = db.Close() })

--- a/services/soso-api/internal/handlers/event.go
+++ b/services/soso-api/internal/handlers/event.go
@@ -1,0 +1,132 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"soso/internal/model"
+	"soso/internal/repository"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+type EventHandler struct {
+	EventRepo *repository.EventRepository
+}
+
+func NewEventHandler(r *repository.EventRepository) *EventHandler {
+	return &EventHandler{EventRepo: r}
+}
+
+/* ----------------------------------------------------------------
+   Request / Response DTO
+   ---------------------------------------------------------------- */
+
+type EventCreateRequest struct {
+	Title               string    `json:"title"                validate:"required,max=128"`
+	Description         string    `json:"description"`
+	StartTime           time.Time `json:"startTime"            validate:"required"`
+	EndTime             time.Time `json:"endTime"              validate:"required"`
+	OriginLocation      string    `json:"originLocation"       validate:"max=255"`
+	DestinationLocation string    `json:"destinationLocation"  validate:"max=255"`
+	SeatsRequired       int       `json:"seatsRequired"        validate:"required,min=1"`
+}
+
+func toEventResponse(e *model.Event) map[string]any {
+	return map[string]any{
+		"id":                  e.ID,
+		"calenderId":          e.CalenderId,
+		"creatorId":           e.CreatorId,
+		"title":               e.Title,
+		"description":         e.Description,
+		"startTime":           e.StartTime,
+		"endTime":             e.EndTime,
+		"originLocation":      e.OriginLocation,
+		"destinationLocation": e.DestinationLocation,
+		"seatsRequired":       e.SeatsRequired,
+	}
+}
+
+/* ----------------------------------------------------------------
+   Handlers
+   ---------------------------------------------------------------- */
+
+// POST /calenders/:calender_id/events
+func (h *EventHandler) Create(c echo.Context) error {
+	calenderID := c.Param("calender_id")
+
+	// JWT からユーザ ID を取得
+	tok, ok := c.Get("user").(*jwt.Token)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+	}
+	claims, ok := tok.Claims.(*jwt.RegisteredClaims)
+	if !ok || claims.Subject == "" {
+		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+	}
+	creatorID := claims.Subject
+
+	// リクエストボディ
+	var req EventCreateRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid payload")
+	}
+	if err := c.Validate(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if !req.EndTime.After(req.StartTime) {
+		return echo.NewHTTPError(http.StatusBadRequest, "endTime must be after startTime")
+	}
+
+	// 登録
+	ev := &model.Event{
+		ID:                  uuid.NewString(),
+		CalenderId:          calenderID,
+		CreatorId:           creatorID,
+		Title:               req.Title,
+		Description:         req.Description,
+		StartTime:           req.StartTime,
+		EndTime:             req.EndTime,
+		OriginLocation:      req.OriginLocation,
+		DestinationLocation: req.DestinationLocation,
+		SeatsRequired:       req.SeatsRequired,
+	}
+
+	if err := h.EventRepo.Create(c.Request().Context(), ev); err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusCreated, toEventResponse(ev))
+}
+
+// GET /calenders/:calender_id/events
+func (h *EventHandler) ListByCalender(c echo.Context) error {
+	calenderID := c.Param("calender_id")
+
+	list, err := h.EventRepo.FindEventsByCalenderId(c.Request().Context(), calenderID)
+	if err != nil {
+		return err
+	}
+
+	resp := make([]map[string]any, len(list))
+	for i, ev := range list {
+		resp[i] = toEventResponse(ev)
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+// GET /events/:event_id
+func (h *EventHandler) FindById(c echo.Context) error {
+	eventID := c.Param("event_id")
+
+	ev, err := h.EventRepo.FindById(c.Request().Context(), eventID)
+	if err != nil {
+		return err
+	}
+	if ev == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "event not found")
+	}
+	return c.JSON(http.StatusOK, toEventResponse(ev))
+}

--- a/services/soso-api/internal/model/event.go
+++ b/services/soso-api/internal/model/event.go
@@ -1,0 +1,19 @@
+package model
+
+import "time"
+
+// Event corresponds to the `events` table.
+type Event struct {
+	ID                  string    `db:"id"`
+	CalenderId          string    `db:"calender_id"`
+	CreatorId           string    `db:"creator_id"`
+	Title               string    `db:"title"`
+	Description         string    `db:"description"`
+	StartTime           time.Time `db:"start_time"`
+	EndTime             time.Time `db:"end_time"`
+	OriginLocation      string    `db:"origin_location"`
+	DestinationLocation string    `db:"destination_location"`
+	SeatsRequired       int       `db:"seats_required"`
+	CreatedAt           time.Time `db:"created_at"`
+	UpdatedAt           time.Time `db:"updated_at"`
+}

--- a/services/soso-api/internal/repository/event.go
+++ b/services/soso-api/internal/repository/event.go
@@ -1,0 +1,126 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"soso/internal/model"
+)
+
+type EventRepository struct {
+	DB *sql.DB
+}
+
+func NewEventRepository(db *sql.DB) *EventRepository {
+	return &EventRepository{DB: db}
+}
+
+// Create inserts a new event record.
+func (r *EventRepository) Create(ctx context.Context, e *model.Event) error {
+	_, err := r.DB.ExecContext(ctx, `
+		INSERT INTO events (
+			id,
+			calender_id,
+			creator_id,
+			title,
+			description,
+			start_time,
+			end_time,
+			origin_location,
+			destination_location,
+			seats_required
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, e.ID, e.CalenderId, e.CreatorId, e.Title, e.Description,
+		e.StartTime, e.EndTime, e.OriginLocation, e.DestinationLocation, e.SeatsRequired)
+	return err
+}
+
+// FindEventsByCalenderId returns all events that belong to a specific calender.
+func (r *EventRepository) FindEventsByCalenderId(ctx context.Context, calenderID string) ([]*model.Event, error) {
+	rows, err := r.DB.QueryContext(ctx, `
+		SELECT
+			id,
+			calender_id,
+			creator_id,
+			title,
+			description,
+			start_time,
+			end_time,
+			origin_location,
+			destination_location,
+			seats_required,
+			created_at,
+			updated_at
+		FROM events
+		WHERE calender_id = ?
+	`, calenderID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var list []*model.Event
+	for rows.Next() {
+		var ev model.Event
+		var desc, origin, dest sql.NullString
+
+		if err := rows.Scan(
+			&ev.ID, &ev.CalenderId, &ev.CreatorId, &ev.Title, &desc,
+			&ev.StartTime, &ev.EndTime, &origin, &dest, &ev.SeatsRequired,
+			&ev.CreatedAt, &ev.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+
+		ev.Description = desc.String
+		ev.OriginLocation = origin.String
+		ev.DestinationLocation = dest.String
+
+		list = append(list, &ev)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+// FindById returns a single event by its ID.
+func (r *EventRepository) FindById(ctx context.Context, eventID string) (*model.Event, error) {
+	row := r.DB.QueryRowContext(ctx, `
+		SELECT
+			id,
+			calender_id,
+			creator_id,
+			title,
+			description,
+			start_time,
+			end_time,
+			origin_location,
+			destination_location,
+			seats_required,
+			created_at,
+			updated_at
+		FROM events
+		WHERE id = ?
+		LIMIT 1
+	`, eventID)
+
+	var ev model.Event
+	var desc, origin, dest sql.NullString
+	if err := row.Scan(
+		&ev.ID, &ev.CalenderId, &ev.CreatorId, &ev.Title, &desc,
+		&ev.StartTime, &ev.EndTime, &origin, &dest, &ev.SeatsRequired,
+		&ev.CreatedAt, &ev.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	ev.Description = desc.String
+	ev.OriginLocation = origin.String
+	ev.DestinationLocation = dest.String
+
+	return &ev, nil
+}

--- a/services/soso-api/internal/validator/event.go
+++ b/services/soso-api/internal/validator/event.go
@@ -1,0 +1,59 @@
+// internal/validator/event.go
+package validator
+
+import (
+	"soso/internal/model"
+	"time"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// RegisterEvent sets up struct-level validation rules for model.Event.
+//
+// 利用例:
+//
+//	v := validator.New()
+//	validator.RegisterEvent(v)
+//	err := v.Struct(event)
+func RegisterEvent(v *validator.Validate) {
+	v.RegisterStructValidation(eventStructValidation, model.Event{})
+}
+
+// eventStructValidation implements cross-field checks for an Event.
+func eventStructValidation(sl validator.StructLevel) {
+	ev := sl.Current().Interface().(model.Event)
+
+	// --- Title: 1–128 文字必須 ---
+	if l := len(ev.Title); l == 0 || l > 128 {
+		sl.ReportError(ev.Title, "Title", "title", "titlelen", "1~128")
+	}
+
+	// --- SeatsRequired: 1 以上 ---
+	if ev.SeatsRequired < 1 {
+		sl.ReportError(ev.SeatsRequired, "SeatsRequired", "seats_required", "seatmin", ">=1")
+	}
+
+	// --- StartTime / EndTime: EndTime は StartTime より後 ---
+	if ev.StartTime.IsZero() {
+		sl.ReportError(ev.StartTime, "StartTime", "start_time", "required", "")
+	}
+	if ev.EndTime.IsZero() {
+		sl.ReportError(ev.EndTime, "EndTime", "end_time", "required", "")
+	}
+	if !ev.EndTime.After(ev.StartTime) {
+		sl.ReportError(ev.EndTime, "EndTime", "end_time", "endafterstart", "")
+	}
+
+	// --- OriginLocation / DestinationLocation: 最大 255 文字 ---
+	if len(ev.OriginLocation) > 255 {
+		sl.ReportError(ev.OriginLocation, "OriginLocation", "origin_location", "max255", "")
+	}
+	if len(ev.DestinationLocation) > 255 {
+		sl.ReportError(ev.DestinationLocation, "DestinationLocation", "destination_location", "max255", "")
+	}
+
+	// --- 任意で: StartTime は未来の日付であること ---
+	if time.Now().After(ev.StartTime) {
+		sl.ReportError(ev.StartTime, "StartTime", "start_time", "future", "")
+	}
+}

--- a/services/soso-api/internal/validator/validator.go
+++ b/services/soso-api/internal/validator/validator.go
@@ -10,6 +10,7 @@ func New() *CustomValidator {
 
 	RegisterUser(v)
 	ResisterCalender(v)
+	RegisterEvent(v)
 
 	return &CustomValidator{v: v}
 }

--- a/services/soso-api/tests/internal/handlers/event_test.go
+++ b/services/soso-api/tests/internal/handlers/event_test.go
@@ -1,0 +1,251 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"soso/internal/handlers"
+	"soso/internal/repository"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+/*
+-------------------------------------------------------------
+
+	テスト用モック生成ヘルパ
+	-------------------------------------------------------------
+*/
+func newEventHandler(t *testing.T) (*handlers.EventHandler, sqlmock.Sqlmock, func(), *echo.Echo) {
+	dbm := NewSQLMock(t)
+	repo := repository.NewEventRepository(dbm.DB)
+	h := handlers.NewEventHandler(repo)
+	e := NewEcho()
+	return h, dbm.Mock, dbm.Close, e
+}
+
+/*
+-------------------------------------------------------------
+
+	Create
+	-------------------------------------------------------------
+*/
+func TestEventCreate_OK(t *testing.T) {
+	h, mock, closeFn, e := newEventHandler(t)
+	defer closeFn()
+
+	mock.ExpectExec(SQLEventCreate).
+		WithArgs(sqlmock.AnyArg(), "cal1", "u1", "Event 1", "desc",
+			sqlmock.AnyArg(), sqlmock.AnyArg(), "A", "B", 2).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	body := `{
+		"title":"Event 1",
+		"description":"desc",
+		"startTime":"2025-08-08T10:00:00Z",
+		"endTime":"2025-08-08T11:00:00Z",
+		"originLocation":"A",
+		"destinationLocation":"B",
+		"seatsRequired":2
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/calenders/cal1/events", bytes.NewBufferString(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/calenders/:calender_id/events")
+	c.SetParamNames("calender_id")
+	c.SetParamValues("cal1")
+
+	SetJWTUser(c, "u1")
+
+	err := h.Create(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEventCreate_InvalidPayload(t *testing.T) {
+	h, _, closeFn, e := newEventHandler(t)
+	defer closeFn()
+
+	req := httptest.NewRequest(http.MethodPost, "/calenders/cal1/events", bytes.NewBufferString(`{`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/calenders/:calender_id/events")
+	c.SetParamNames("calender_id")
+	c.SetParamValues("cal1")
+
+	SetJWTUser(c, "u1")
+
+	err := h.Create(c)
+	assert.Error(t, err)
+	he := err.(*echo.HTTPError)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+}
+
+func TestEventCreate_Unauthorized(t *testing.T) {
+	h, _, closeFn, e := newEventHandler(t)
+	defer closeFn()
+
+	req := httptest.NewRequest(http.MethodPost, "/calenders/cal1/events", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/calenders/:calender_id/events")
+	c.SetParamNames("calender_id")
+	c.SetParamValues("cal1")
+
+	err := h.Create(c)
+	assert.Error(t, err)
+	he := err.(*echo.HTTPError)
+	assert.Equal(t, http.StatusUnauthorized, he.Code)
+}
+
+/*
+-------------------------------------------------------------
+
+	ListByCalender
+	-------------------------------------------------------------
+*/
+func TestEventListByCalender_OK(t *testing.T) {
+	h, mock, closeFn, e := newEventHandler(t)
+	defer closeFn()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "calender_id", "creator_id", "title", "description",
+		"start_time", "end_time", "origin_location", "destination_location",
+		"seats_required", "created_at", "updated_at",
+	}).AddRow(
+		"ev1", "cal1", "u1", "Event 1", "desc1",
+		now, now.Add(time.Hour), "A1", "B1", 1, now, now,
+	).AddRow(
+		"ev2", "cal1", "u2", "Event 2", "desc2",
+		now.Add(2*time.Hour), now.Add(3*time.Hour), "A2", "B2", 3, now, now,
+	)
+
+	mock.ExpectQuery(SQLEventFindByCalenderID).
+		WithArgs("cal1").
+		WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodGet, "/calenders/cal1/events", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/calenders/:calender_id/events")
+	c.SetParamNames("calender_id")
+	c.SetParamValues("cal1")
+
+	err := h.ListByCalender(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var got []map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Len(t, got, 2)
+	assert.Equal(t, "ev1", got[0]["id"])
+	assert.Equal(t, "Event 2", got[1]["title"])
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEventListByCalender_NotFound(t *testing.T) {
+	h, mock, closeFn, e := newEventHandler(t)
+	defer closeFn()
+
+	empty := sqlmock.NewRows([]string{
+		"id", "calender_id", "creator_id", "title", "description",
+		"start_time", "end_time", "origin_location", "destination_location",
+		"seats_required", "created_at", "updated_at",
+	})
+	mock.ExpectQuery(SQLEventFindByCalenderID).
+		WithArgs("cal1").
+		WillReturnRows(empty)
+
+	req := httptest.NewRequest(http.MethodGet, "/calenders/cal1/events", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/calenders/:calender_id/events")
+	c.SetParamNames("calender_id")
+	c.SetParamValues("cal1")
+
+	err := h.ListByCalender(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var got []map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Len(t, got, 0)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+/*
+-------------------------------------------------------------
+
+	FindById
+	-------------------------------------------------------------
+*/
+func TestEventFindById_OK(t *testing.T) {
+	h, mock, closeFn, e := newEventHandler(t)
+	defer closeFn()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "calender_id", "creator_id", "title", "description",
+		"start_time", "end_time", "origin_location", "destination_location",
+		"seats_required", "created_at", "updated_at",
+	}).AddRow(
+		"ev1", "cal1", "u1", "Event 1", "desc1",
+		now, now.Add(time.Hour), "A", "B", 2, now, now,
+	)
+
+	mock.ExpectQuery(SQLEventFindById).
+		WithArgs("ev1").
+		WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodGet, "/events/ev1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/events/:event_id")
+	c.SetParamNames("event_id")
+	c.SetParamValues("ev1")
+
+	err := h.FindById(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var got map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "Event 1", got["title"])
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEventFindById_NotFound(t *testing.T) {
+	h, mock, closeFn, e := newEventHandler(t)
+	defer closeFn()
+
+	mock.ExpectQuery(SQLEventFindById).
+		WithArgs("ev1").
+		WillReturnRows(sqlmock.NewRows([]string{}))
+
+	req := httptest.NewRequest(http.MethodGet, "/events/ev1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/events/:event_id")
+	c.SetParamNames("event_id")
+	c.SetParamValues("ev1")
+
+	err := h.FindById(c)
+	assert.Error(t, err)
+	he := err.(*echo.HTTPError)
+	assert.Equal(t, http.StatusNotFound, he.Code)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/services/soso-api/tests/internal/handlers/helpers_test.go
+++ b/services/soso-api/tests/internal/handlers/helpers_test.go
@@ -204,4 +204,52 @@ const (
 		INNER JOIN users AS u ON u.id = cm.user_id
 		WHERE cm.calender_id = ?
 	`
+	SQLEventCreate = `
+		INSERT INTO events (
+			id,
+			calender_id,
+			creator_id,
+			title,
+			description,
+			start_time,
+			end_time,
+			origin_location,
+			destination_location,
+			seats_required
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+
+	SQLEventFindByCalenderID = `
+		SELECT
+			id,
+			calender_id,
+			creator_id,
+			title,
+			description,
+			start_time,
+			end_time,
+			origin_location,
+			destination_location,
+			seats_required,
+			created_at,
+			updated_at
+		FROM events
+		WHERE calender_id = ?`
+
+	SQLEventFindById = `
+		SELECT
+			id,
+			calender_id,
+			creator_id,
+			title,
+			description,
+			start_time,
+			end_time,
+			origin_location,
+			destination_location,
+			seats_required,
+			created_at,
+			updated_at
+		FROM events
+		WHERE id = ?
+		LIMIT 1`
 )

--- a/services/soso-api/tests/internal/repository/event_test.go
+++ b/services/soso-api/tests/internal/repository/event_test.go
@@ -1,0 +1,192 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+
+	"soso/internal/model"
+	"soso/internal/repository"
+)
+
+/*
+----------------------------------------------------------------
+
+	モック生成ヘルパ
+	----------------------------------------------------------------
+*/
+func newEventRepoMock(t *testing.T) (*repository.EventRepository, sqlmock.Sqlmock, func()) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	assert.NoError(t, err)
+	return repository.NewEventRepository(db), mock, func() { _ = db.Close() }
+}
+
+/*
+----------------------------------------------------------------
+
+	Create
+	----------------------------------------------------------------
+*/
+func TestEventRepository_Create_OK(t *testing.T) {
+	repo, mock, closeFn := newEventRepoMock(t)
+	defer closeFn()
+
+	e := &model.Event{
+		ID:                  "ev1",
+		CalenderId:          "cal1",
+		CreatorId:           "u1",
+		Title:               "Event 1",
+		Description:         "desc",
+		StartTime:           time.Now(),
+		EndTime:             time.Now().Add(time.Hour),
+		OriginLocation:      "A",
+		DestinationLocation: "B",
+		SeatsRequired:       2,
+	}
+
+	mock.ExpectExec(SQLEventCreate).
+		WithArgs(e.ID, e.CalenderId, e.CreatorId, e.Title, e.Description,
+			e.StartTime, e.EndTime, e.OriginLocation, e.DestinationLocation, e.SeatsRequired).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := repo.Create(context.Background(), e)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEventRepository_Create_DuplicateID(t *testing.T) {
+	repo, mock, closeFn := newEventRepoMock(t)
+	defer closeFn()
+
+	e := &model.Event{
+		ID:                  "ev1",
+		CalenderId:          "cal1",
+		CreatorId:           "u1",
+		Title:               "Event 1",
+		Description:         "desc",
+		StartTime:           time.Now(),
+		EndTime:             time.Now().Add(time.Hour),
+		OriginLocation:      "A",
+		DestinationLocation: "B",
+		SeatsRequired:       2,
+	}
+
+	mock.ExpectExec(SQLEventCreate).
+		WithArgs(e.ID, e.CalenderId, e.CreatorId, e.Title, e.Description,
+			e.StartTime, e.EndTime, e.OriginLocation, e.DestinationLocation, e.SeatsRequired).
+		WillReturnError(&mysql.MySQLError{
+			Number:  1062,
+			Message: "Duplicate entry 'ev1' for key 'events.PRIMARY'",
+		})
+
+	err := repo.Create(context.Background(), e)
+	assert.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+/*
+----------------------------------------------------------------
+
+	FindById
+	----------------------------------------------------------------
+*/
+func TestEventRepository_FindById_Hit(t *testing.T) {
+	repo, mock, closeFn := newEventRepoMock(t)
+	defer closeFn()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "calender_id", "creator_id", "title", "description",
+		"start_time", "end_time", "origin_location", "destination_location",
+		"seats_required", "created_at", "updated_at",
+	}).AddRow(
+		"ev1", "cal1", "u1", "Event 1", "desc",
+		now, now.Add(time.Hour), "A", "B",
+		2, now, now,
+	)
+
+	mock.ExpectQuery(SQLEventFindById).
+		WithArgs("ev1").
+		WillReturnRows(rows)
+
+	ev, err := repo.FindById(context.Background(), "ev1")
+	assert.NoError(t, err)
+	assert.NotNil(t, ev)
+	assert.Equal(t, "Event 1", ev.Title)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEventRepository_FindById_NotFound(t *testing.T) {
+	repo, mock, closeFn := newEventRepoMock(t)
+	defer closeFn()
+
+	mock.ExpectQuery(SQLEventFindById).
+		WithArgs("ev1").
+		WillReturnRows(sqlmock.NewRows([]string{}))
+
+	ev, err := repo.FindById(context.Background(), "ev1")
+	assert.NoError(t, err)
+	assert.Nil(t, ev)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+/*
+----------------------------------------------------------------
+
+	FindEventsByCalenderId
+	----------------------------------------------------------------
+*/
+func TestEventRepository_FindEventsByCalenderId_Hit(t *testing.T) {
+	repo, mock, closeFn := newEventRepoMock(t)
+	defer closeFn()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "calender_id", "creator_id", "title", "description",
+		"start_time", "end_time", "origin_location", "destination_location",
+		"seats_required", "created_at", "updated_at",
+	}).AddRow(
+		"ev1", "cal1", "u1", "Event 1", "desc1",
+		now, now.Add(time.Hour), "A1", "B1",
+		1, now, now,
+	).AddRow(
+		"ev2", "cal1", "u2", "Event 2", "desc2",
+		now.Add(2*time.Hour), now.Add(3*time.Hour), "A2", "B2",
+		3, now, now,
+	)
+
+	mock.ExpectQuery(SQLEventFindByCalenderID).
+		WithArgs("cal1").
+		WillReturnRows(rows)
+
+	list, err := repo.FindEventsByCalenderId(context.Background(), "cal1")
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+	assert.Equal(t, "ev1", list[0].ID)
+	assert.Equal(t, "Event 2", list[1].Title)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEventRepository_FindEventsByCalenderId_NotFound(t *testing.T) {
+	repo, mock, closeFn := newEventRepoMock(t)
+	defer closeFn()
+
+	emptyRows := sqlmock.NewRows([]string{
+		"id", "calender_id", "creator_id", "title", "description",
+		"start_time", "end_time", "origin_location", "destination_location",
+		"seats_required", "created_at", "updated_at",
+	})
+
+	mock.ExpectQuery(SQLEventFindByCalenderID).
+		WithArgs("cal1").
+		WillReturnRows(emptyRows)
+
+	list, err := repo.FindEventsByCalenderId(context.Background(), "cal1")
+	assert.NoError(t, err)
+	assert.Len(t, list, 0)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/services/soso-api/tests/internal/repository/helpers_test.go
+++ b/services/soso-api/tests/internal/repository/helpers_test.go
@@ -179,4 +179,52 @@ const (
 		INNER JOIN users AS u ON u.id = cm.user_id
 		WHERE cm.calender_id = ?
 	`
+	SQLEventCreate = `
+		INSERT INTO events (
+			id,
+			calender_id,
+			creator_id,
+			title,
+			description,
+			start_time,
+			end_time,
+			origin_location,
+			destination_location,
+			seats_required
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+
+	SQLEventFindById = `
+		SELECT
+			id,
+			calender_id,
+			creator_id,
+			title,
+			description,
+			start_time,
+			end_time,
+			origin_location,
+			destination_location,
+			seats_required,
+			created_at,
+			updated_at
+		FROM events
+		WHERE id = ?
+		LIMIT 1`
+
+	SQLEventFindByCalenderID = `
+		SELECT
+			id,
+			calender_id,
+			creator_id,
+			title,
+			description,
+			start_time,
+			end_time,
+			origin_location,
+			destination_location,
+			seats_required,
+			created_at,
+			updated_at
+		FROM events
+		WHERE calender_id = ?`
 )


### PR DESCRIPTION
# 概要  
- カレンダーに紐づくイベントの作成・取得 API を実装した  

# やったこと  
- **EventRepository**（Create／FindEventsByCalenderId／FindById）の実装  
- **EventHandler**  
  - `POST   /calenders/{calender_id}/events` イベント作成  
  - `GET    /calenders/{calender_id}/events` カレンダー内イベント一覧取得  
  - `GET    /events/{event_id}`       イベント詳細取得  
- `internal/validator/event.go` で Event 用バリデータを追加  
- それぞれのユニットテストとハンドラテストを実装  

# 仕様  

| HTTP | URI | 認証 | CSRF | 説明 |
|------|-----|------|------|------|
| POST | `/calenders/{calender_id}/events` | 必須 | 必須 | イベントを新規作成する |
| GET  | `/calenders/{calender_id}/events` | 必須 | 必須 | 指定カレンダーのイベント一覧を取得する |
| GET  | `/events/{event_id}`              | 必須 | 不要 | イベント ID で 1 件取得する |

---

## 1. イベント作成  
### リクエスト  
`POST /calenders/{calender_id}/events`  

```json
{
  "title": "ランチミーティング",
  "description": "フードコート集合",
  "startTime": "2025-08-08T11:30:00Z",
  "endTime": "2025-08-08T12:30:00Z",
  "originLocation": "NUT正門前",
  "destinationLocation": "イオン長岡",
  "seatsRequired": 3
}
```

### レスポンス  
#### 作成成功  
`201`  
```json
{
  "id": "2ba68c79-8c82-4dd2-84f7-b5f0c54bfe5e",
  "calenderId": "cal1",
  "creatorId": "u1",
  "title": "ランチミーティング",
  "description": "フードコート集合",
  "startTime": "2025-08-08T11:30:00Z",
  "endTime": "2025-08-08T12:30:00Z",
  "originLocation": "NUT正門前",
  "destinationLocation": "イオン長岡",
  "seatsRequired": 3
}
```

#### 形式不正  
`400`  
```json
{
  "message": "endTime must be after startTime"
}
```

#### 認証失敗  
`401`  
```json
{
  "message": "unauthorized"
}
```

---

## 2. カレンダー内イベント一覧取得  
### リクエスト  
`GET /calenders/{calender_id}/events`  

パラメータおよびボディなし  

### レスポンス  
#### 取得成功  
`200`  
```json
[
  {
    "id": "ev1",
    "calenderId": "cal1",
    "creatorId": "u1",
    "title": "ランチミーティング",
    "description": "フードコート集合",
    "startTime": "2025-08-08T11:30:00Z",
    "endTime": "2025-08-08T12:30:00Z",
    "originLocation": "NUT正門前",
    "destinationLocation": "イオン長岡",
    "seatsRequired": 3
  },
  {
    "id": "ev2",
    "calenderId": "cal1",
    "creatorId": "u2",
    "title": "帰省送迎",
    "description": "",
    "startTime": "2025-08-10T09:00:00Z",
    "endTime": "2025-08-10T13:00:00Z",
    "originLocation": "長岡駅",
    "destinationLocation": "新潟空港",
    "seatsRequired": 2
  }
]
```

#### 認証失敗  
`401`  
```json
{
  "message": "unauthorized"
}
```

---

## 3. イベント詳細取得  
### リクエスト  
`GET /events/{event_id}`  

### レスポンス  
#### 取得成功  
`200`  
```json
{
  "id": "ev1",
  "calenderId": "cal1",
  "creatorId": "u1",
  "title": "ランチミーティング",
  "description": "フードコート集合",
  "startTime": "2025-08-08T11:30:00Z",
  "endTime": "2025-08-08T12:30:00Z",
  "originLocation": "NUT正門前",
  "destinationLocation": "イオン長岡",
  "seatsRequired": 3
}
```

#### 未登録 ID  
`404`  
```json
{
  "message": "event not found"
}
```

#### 認証失敗  
`401`  
```json
{
  "message": "unauthorized"
}
```

---
