### PR TITLE
Feat/kanba/add dashboard page2

### DIFF
--- a/services/soso-web/src/app/resister/page.tsx
+++ b/services/soso-web/src/app/resister/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useState, useEffect } from 'react'
-import axios from 'axios'
-import Image from 'next/image'
+import { useState, useEffect } from 'react';
+import Image from 'next/image';
 import Input from '../../components/TextFieald/Input';
 import Button from '../../components/Button/Button';
 import { useRouter } from 'next/navigation';
@@ -10,53 +9,111 @@ import Radio from '@/src/components/Button/RadioButton';
 import Dropdown from '@/src/components/DropdownMenu/DropdownMenu';
 
 export default function RegisterPage() {
-  const router = useRouter(); // ★ この行を追加
-  const [username, setUsername] = useState('')
-  const [mailAddress, setMailAddress] = useState('')
-  const [password, setPassword] = useState('')
-  const [token, setToken] = useState('')
-  const [csrfToken, setCsrfToken] = useState('')
-  const [userInfo, setUserInfo] = useState<any>(null)
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [mailAddress, setMailAddress] = useState('');
+  const [password, setPassword] = useState('');
+  const [csrfToken, setCsrfToken] = useState('');
   const [hasCar, setHasCar] = useState(true);
   const [capacity, setCapacity] = useState(4);
+  const [loading, setLoading] = useState(false); // ローディング状態を追加
 
-  const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || ''
+  const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
+  const validateForm = () => {
+  // ユーザー名: 3-30文字、英数字とアンダースコアのみ
+  if (!/^[a-zA-Z0-9_]{3,30}$/.test(username)) {
+    alert('ユーザー名は3-30文字で、英数字とアンダースコアのみ使用可能です');
+    return false;
+  }
+  
+  // パスワード: 8-72文字
+  if (password.length < 8 || password.length > 72) {
+    alert('パスワードは8-72文字で入力してください');
+    return false;
+  }
+  
+  // メールアドレス
+  if (!/^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/.test(mailAddress)) {
+    alert('有効なメールアドレスを入力してください');
+    return false;
+  }
+  
+  // 車を持っている場合、capacityは1以上
+  if (hasCar && capacity <= 0) {
+    alert('車を所有する場合、乗車可能人数を1以上で設定してください');
+    return false;
+  }
+  
+  return true;
+};
 
   useEffect(() => {
-    // const fetchCsrfToken = async () => {
-    //   try {
-    //     const res = await axios.get(`${API_BASE}/auth/csrf`, {
-    //       withCredentials: true
-    //     })
-    //     setCsrfToken(res.data.csrf_token)
-    //   } catch (err: any) {
-    //     console.error('CSRFトークン取得失敗', err)
-    //   }
-    // }
-
-    // fetchCsrfToken()
-  }, [API_BASE])
+    const fetchCsrfToken = async () => {
+      try {
+        const response = await fetch(`${API_BASE}/auth/csrf`, {
+          method: 'GET',
+          credentials: 'include',
+        });
+        
+        if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || `HTTP ${response.status}: Registration failed`);
+    }
+        
+        const data = await response.json();
+        setCsrfToken(data.csrf_token);
+        console.log('CSRFトークン取得成功:', data.csrf_token);
+      } catch (err: any) {
+        console.error('CSRFトークン取得失敗', err);
+      }
+    };
+    
+    fetchCsrfToken();
+  }, [API_BASE]);
 
   const register = async () => {
-    try {
-    //   await axios.post(`${API_BASE}/users/register`, {
-    //     username,
-    //     mailAddress,
-    //     password,
-    //     hasCar: hasCar,
-    //     capacity: capacity
-    //   }, {
-    //     headers: { 'X-CSRF-Token': csrfToken },
-    //     withCredentials: true
-    //   })
-      alert('登録成功')
-      router.push('../');
-    } catch (err: any) {
-      alert('登録失敗: ' + err.response?.data?.message)
-    }
+    if (!validateForm()) return;
+  
+  if (!csrfToken) {
+    alert('CSRF トークンが取得できていません。ページを再読み込みしてください。');
+    return;
   }
 
-  const capacityOptions = [1, 2, 3, 4, 5, 6, 7, 8]
+    setLoading(true);
+    try {
+      const response = await fetch(`${API_BASE}/users/register`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
+        },
+        body: JSON.stringify({
+          username,
+          mailAddress,
+          password,
+          hasCar: hasCar,
+          capacity: hasCar ? capacity : 0, // 車がない場合は0
+        }),
+      });
+
+       if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || `HTTP ${response.status}: Registration failed`);
+    }
+      const data = await response.json();
+      console.log('登録成功:', data);
+      alert('登録成功');
+      router.push('../');
+    } catch (err: any) {
+      console.error('登録失敗:', err);
+      alert('登録失敗: ' + err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const capacityOptions = [1, 2, 3, 4, 5, 6, 7, 8];
   const dropdownTrigger = (
     <div className="w-full border border-gray-300 rounded-md px-3 py-2 bg-white flex justify-between items-center cursor-pointer !h-11">
         {capacity}人
@@ -93,7 +150,7 @@ export default function RegisterPage() {
             <Input
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="!h-11 !rounded-md bg-white w-full max-w-md" 
+              className="!h-11 !rounded-md bg-white w-full max-w-md"
             />
           </div>
           <div>
@@ -103,7 +160,7 @@ export default function RegisterPage() {
             <Input
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-              className="!h-11 !rounded-md bg-white w-full max-w-md" 
+              className="!h-11 !rounded-md bg-white w-full max-w-md"
             />
           </div>
         <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -136,7 +193,6 @@ export default function RegisterPage() {
                 <div
                   key={num}
                   className="px-4 py-2 hover:bg-gray-100 cursor-pointer text-center"
-                  // 選択肢がクリックされたらcapacityの状態を更新
                   onClick={() => setCapacity(num)}
                 >
                   {num}人

--- a/services/soso-web/src/app/resister/page.tsx
+++ b/services/soso-web/src/app/resister/page.tsx
@@ -202,9 +202,19 @@ export default function RegisterPage() {
         </div>
         <Button
           onClick={register}
-          className="bg-gray-600 hover:bg-gray-700 text-white w-full max-w-md flex justify-center"
+          className={`bg-gray-600 hover:bg-gray-700 text-white w-full max-w-md flex justify-center ${
+            loading ? 'opacity-50 cursor-not-allowed' : ''
+          }`}
+          disabled={loading}
         >
-        登録
+          {loading ? (
+            <div className="flex items-center">
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
+              登録中...
+            </div>
+          ) : (
+            '登録'
+          )}
         </Button>
         </div>
       </div>


### PR DESCRIPTION
# 概要
1. ページロード
   ↓
2. GET /auth/csrf
   ← CSRFトークン取得
   ↓
3. ユーザーがフォーム入力
   ↓
4. 登録ボタンクリック
   ↓
5. フロントエンドバリデーション
   ↓
6. POST /users/register (CSRFトークン付き)
   ← 登録成功/失敗レスポンス
   ↓
7. 成功時：メインページへ遷移
   失敗時：エラーメッセージ表示
   
  この処理を実装しました
  送るJSONの形式は以下の通りです
  
 ```
 body: JSON.stringify({
  username,        // ← JSON key
  mailAddress,     // ← JSON key
  password,        // ← JSON key
  hasCar: hasCar,  // ← JSON key
  capacity: hasCar ? capacity : 0, // ← JSON key
}),
```

おそらくバックエンドと変わってないはず

```
type RegisterRequest struct {
    Username    string `json:"username"`    // ← JSONタグ
    MailAddress string `json:"mailAddress"` // ← JSONタグ
    Password    string `json:"password"`    // ← JSONタグ
    HasCar      bool   `json:"hasCar"`      // ← JSONタグ
    Capacity    int    `json:"capacity"`    // ← JSONタグ
}
```