### PR TITLE
Fix/kitano/fetch-csrf-web CSRFトークンを取得できない問題を解消

### DIFF
--- a/services/soso-web/package-lock.json
+++ b/services/soso-web/package-lock.json
@@ -28,6 +28,7 @@
         "@storybook/addon-vitest": "^9.1.0",
         "@storybook/nextjs-vite": "^9.1.0",
         "@tailwindcss/postcss": "^4",
+        "@types/js-cookie": "^3.0.6",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2635,6 +2636,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/services/soso-web/package-lock.json
+++ b/services/soso-web/package-lock.json
@@ -14,6 +14,7 @@
         "@fullcalendar/react": "^6.1.18",
         "axios": "^1.11.0",
         "clsx": "^2.1.1",
+        "js-cookie": "^3.0.5",
         "next": "^15.4.4",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -3966,6 +3967,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/services/soso-web/package.json
+++ b/services/soso-web/package.json
@@ -17,6 +17,7 @@
     "@fullcalendar/react": "^6.1.18",
     "axios": "^1.11.0",
     "clsx": "^2.1.1",
+    "js-cookie": "^3.0.5",
     "next": "^15.4.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/services/soso-web/package.json
+++ b/services/soso-web/package.json
@@ -31,6 +31,7 @@
     "@storybook/addon-vitest": "^9.1.0",
     "@storybook/nextjs-vite": "^9.1.0",
     "@tailwindcss/postcss": "^4",
+    "@types/js-cookie": "^3.0.6",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/services/soso-web/src/app/page.tsx
+++ b/services/soso-web/src/app/page.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import Input from '../components/TextFieald/Input';
 import Button from '../components/Button/Button';
 import { useRouter } from 'next/navigation';
+import Cookies from "js-cookie"
 
 export default function Home() {
   const router = useRouter();
@@ -20,7 +21,6 @@ export default function Home() {
   useEffect(() => {
     const fetchCsrfToken = async () => {
       console.log('CSRFトークン取得開始...');
-      try {
         const res = await fetch(`${API_BASE}/auth/csrf`, {
           method: 'GET',
           credentials: 'include'
@@ -28,12 +28,8 @@ export default function Home() {
         if (!res.ok) {
           throw new Error(`HTTPエラー: ${res.status}`);
         }
-        const data = await res.json();
-        setCsrfToken(data.csrf_token);
-        console.log('✅ CSRFトークン取得成功:', data.csrf_token);
-      } catch (err: any) {
-        console.error('❌ CSRFトークン取得失敗:', err);
-      }
+        const csrfToken = Cookies.get(`csrf_token`)?.toString ?? ""
+        setCsrfToken(csrfToken);
     };
 
     fetchCsrfToken();

--- a/services/soso-web/src/app/resister/page.tsx
+++ b/services/soso-web/src/app/resister/page.tsx
@@ -7,6 +7,7 @@ import Button from '../../components/Button/Button';
 import { useRouter } from 'next/navigation';
 import Radio from '@/src/components/Button/RadioButton';
 import Dropdown from '@/src/components/DropdownMenu/DropdownMenu';
+import Cookies from 'js-cookie';
 
 export default function RegisterPage() {
   const router = useRouter();
@@ -49,7 +50,6 @@ export default function RegisterPage() {
 
   useEffect(() => {
     const fetchCsrfToken = async () => {
-      try {
         const response = await fetch(`${API_BASE}/auth/csrf`, {
           method: 'GET',
           credentials: 'include',
@@ -58,14 +58,10 @@ export default function RegisterPage() {
         if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
       throw new Error(errorData.message || `HTTP ${response.status}: Registration failed`);
-    }
+        }
         
-        const data = await response.json();
-        setCsrfToken(data.csrf_token);
-        console.log('CSRFトークン取得成功:', data.csrf_token);
-      } catch (err: any) {
-        console.error('CSRFトークン取得失敗', err);
-      }
+        const csrfToken = Cookies.get(`csrf_token`)?.toString ?? ""
+        setCsrfToken(csrfToken);
     };
     
     fetchCsrfToken();
@@ -74,10 +70,6 @@ export default function RegisterPage() {
   const register = async () => {
     if (!validateForm()) return;
   
-  if (!csrfToken) {
-    alert('CSRF トークンが取得できていません。ページを再読み込みしてください。');
-    return;
-  }
 
     setLoading(true);
     try {


### PR DESCRIPTION
# 概要
ResisterとLoginページでCSRFトークンを取得できない問題を解消

# なんで？
- /auth/csrf はそもそもレスポンスを返さない（Cookieに保存されます）
- js-cookieライブラリを使用してCookieからcsrftokenを取得します

```
if (!csrfToken) {
   log.console(csrfトークン取得できません！)
}
```

このようなコードがありましたが、これ不要です。まず、IF文の!csrfTokenですが、そもそもcsrfTokenはstring型が期待されるので、この条件式では確実にFalseになってしまいます。
また、CSRFトークン取得APIをFetchできないというのは、APIサーバーが死んでいると同等なので、CSRFトークンがFetchできないというのはあんまり考えなくていいと思います。

また、Fetchをする際にTry Catchをするのは良くないかも？

なぜか？

catch error anyとしてしまうと、エラーが吸われてしまってどんなエラーが起きているかがConsoleやNetworkで確認できないため