### PR TITLE
[fix]イベント作成時に親コンポーネントから渡されたメンバーから、メンバーを動的に取得できるようにしました

### DIFF
--- a/services/soso-web/src/app/dashboard/[name]/page.tsx
+++ b/services/soso-web/src/app/dashboard/[name]/page.tsx
@@ -112,7 +112,7 @@ const DashboardPage: NextPage<DashboardPageProps> = ({ params }) => {
     pickUpCount: 0,
     departurePoint: '',
     destinationPoint: '',
-    members: []
+    members: ['田中 太郎', '佐藤 花子', '山田 次郎'],
   };
 
   // page.tsx - 重複している handleSaveSosoChange 関数を1つにまとめる

--- a/services/soso-web/src/app/dashboard/[name]/page.tsx
+++ b/services/soso-web/src/app/dashboard/[name]/page.tsx
@@ -112,7 +112,7 @@ const DashboardPage: NextPage<DashboardPageProps> = ({ params }) => {
     pickUpCount: 0,
     departurePoint: '',
     destinationPoint: '',
-    members: ['田中 太郎', '佐藤 花子', '山田 次郎'],
+    members: members.map(member => member.username), // 初期メンバーを設定
   };
 
   // page.tsx - 重複している handleSaveSosoChange 関数を1つにまとめる

--- a/services/soso-web/src/components/Modal/EventAddModal.tsx
+++ b/services/soso-web/src/components/Modal/EventAddModal.tsx
@@ -26,13 +26,11 @@ interface EventAddModalProps {
   onSave: (status: EventStatus) => void;
   initialStatus: EventStatus;
 }
-
-// 参加者データの仮配列
-const initialParticipants = [
-  { id: 1, name: '田中太郎', isChecked: false },
-  { id: 2, name: '佐藤花子', isChecked: false },
-  { id: 3, name: '山田次郎', isChecked: false },
-];
+interface Participant {
+  id: number;
+  name: string;
+  isChecked: boolean;
+}
 
 const EventAddModal: React.FC<EventAddModalProps> = ({
   isOpen,
@@ -49,7 +47,9 @@ const EventAddModal: React.FC<EventAddModalProps> = ({
   const [pickUpCount, setPickUpCount] = useState(initialStatus.pickUpCount);
   const [departurePoint, setDeparturePoint] = useState(initialStatus.departurePoint);
   const [destinationPoint, setDestinationPoint] = useState(initialStatus.destinationPoint);
-  const [participants, setParticipants] = useState(initialParticipants);
+
+  const [participants, setParticipants] = useState<Participant[]>([]);
+
   const [dropOffCountInput, setDropOffCountInput] = useState(
   initialStatus.dropOffCount === 0 ? '' : String(initialStatus.dropOffCount)
 );
@@ -87,7 +87,18 @@ const EventAddModal: React.FC<EventAddModalProps> = ({
       setPickUpCount(initialStatus.pickUpCount);
       setDeparturePoint(initialStatus.departurePoint);
       setDestinationPoint(initialStatus.destinationPoint);
-      setParticipants(initialParticipants.map(p => ({ ...p, isChecked: false })));
+      //setParticipants(initialStatus.members.map(p => ({ ...p, isChecked: false })));
+      setParticipants(
+        initialStatus.members.map((memberName, index) => ({
+          id: index + 1,
+          name: memberName,
+          isChecked: false
+        }))
+      );
+
+      
+
+      //string[]からPar
     }
   }, [isOpen, initialStatus]);
 
@@ -103,8 +114,8 @@ const EventAddModal: React.FC<EventAddModalProps> = ({
   }, [isOpen]);
 
   const handleCheckboxChange = (id: number) => {
-    setParticipants(
-      participants.map(p =>
+    setParticipants(prevParticipants =>
+      prevParticipants.map(p =>
         p.id === id ? { ...p, isChecked: !p.isChecked } : p
       )
     );


### PR DESCRIPTION
# 概要
親コンポーネントから渡されたメンバーのリストをイベント登録時に開くモーダルで取得できるように変更しました

# スクリーンショット
<img width="305" height="453" alt="スクリーンショット 2025-08-11 0 10 28" src="https://github.com/user-attachments/assets/d8082c73-e4ba-43a5-a3c6-d2c58c871560" />
<img width="356" height="183" alt="スクリーンショット 2025-08-11 0 12 09" src="https://github.com/user-attachments/assets/2b5a1990-a499-4ddf-ba74-3ba8f15af0fd" />
<img width="508" height="471" alt="スクリーンショット 2025-08-11 0 12 24" src="https://github.com/user-attachments/assets/5f8ba2bb-a6b5-4714-a473-3299d641b3e4" />
