### PR TITLE
[add]storybookにprofileを追加して、storybookを使うときは明示的にビルドし直すように変更した

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,18 @@ api:
 	$(DC) build soso-api soso-database soso-api-document
 	$(DC) up -d soso-api soso-database soso-api-document
 
-## 全ビルドし直して起動（キャッシュなし）
+# Storybook 使うときだけ明示してビルド/起動
+storybook-up:
+	COMPOSE_PROFILES=storybook $(DC) up -d soso-web-storybook
+
+storybook-build:
+	COMPOSE_PROFILES=storybook $(DC) build --no-cache soso-web-storybook
+	COMPOSE_PROFILES=storybook $(DC) up -d soso-web-storybook
+
+## Storybook以外ビルドし直して起動（キャッシュなし）
 rebuild:
 	$(DC) down -v --remove-orphans
-	$(DC) build --no-cache
+	$(DC) build --no-cache soso-api soso-database soso-api-document soso-web
 	$(DC) up -d
 
 dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
       - soso-api
 
   soso-web-storybook:
+    profiles: ["storybook"]
     build:
       context: services/soso-web
       dockerfile: Dockerfile.storybook  # Storybook用Dockerfileを指定


### PR DESCRIPTION
# 概要
ブランチ名の通り
storybook使ってないのに毎回ビルド遅かったから、プロフィールをつけて、明示しないと起動しないようにした