### PR TITLE
fix: リフレッシュトークンが４０３だったら、セッション切れページに遷移するように修正

### DIFF
--- a/services/soso-web/src/app/auth/tokenexpired/page.tsx
+++ b/services/soso-web/src/app/auth/tokenexpired/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+
+type Props = {
+  searchParams?: { next?: string };
+};
+
+export default function TokenExpiredPage({ searchParams }: Props) {
+  const next = searchParams?.next ?? "/";
+
+  return (
+    <div className="flex w-full flex-col items-center justify-center text-center gap-4 px-6">
+      <h1 className="text-xl font-semibold tracking-tight">
+        セッションの有効期限が切れました
+      </h1>
+
+      <p className="text-sm leading-6 text-muted-foreground">
+        お手数ですが再度ログインしてください。
+      </p>
+
+      <Link
+        href={`/auth/login?next=${encodeURIComponent(next)}`}
+        className="mt-2 inline-flex items-center justify-center rounded-md bg-primary px-6 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+      >
+        ログイン画面へ
+      </Link>
+    </div>
+  );
+}

--- a/services/soso-web/src/contexts/AuthContext.tsx
+++ b/services/soso-web/src/contexts/AuthContext.tsx
@@ -8,9 +8,10 @@ import React, {
   useMemo,
   useState,
 } from "react";
+import { usePathname } from "next/navigation";
 import type { User } from "@/types/interfaces";
 import { getMe } from "@/requests/userAPI";
-import { refreshAccessToken, logout as apiLogout } from "@/requests/authAPI";
+import { logout as apiLogout } from "@/requests/authAPI";
 
 // --------------------
 // State Context
@@ -26,21 +27,8 @@ const AuthStateContext = createContext<AuthState | null>(null);
 // Actions Context
 // --------------------
 type AuthActions = {
-  /**
-   * access token が既に有効な前提で /users/me を叩いて user を更新する
-   * (ログイン直後に使う想定)
-   */
   fetchMe: () => Promise<User>;
-
-  /**
-   * rt cookie -> /auth/refresh で access token 再発行してから /users/me
-   * (リロード直後に使う想定)
-   */
   reloadMe: () => Promise<User>;
-
-  /**
-   * /auth/logout して tokenStore を消し、user も null にする
-   */
   logout: () => Promise<void>;
 };
 
@@ -50,44 +38,50 @@ const AuthActionsContext = createContext<AuthActions | null>(null);
 // Provider
 // --------------------
 export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  // access token がある前提で me を取得
+  // access token が有効（または interceptor により refresh 済み）な前提で me を取得
   const fetchMe = useCallback(async (): Promise<User> => {
-    const me = await getMe();
+    const me = await getMe(); // 401/403なら client.ts interceptor が refresh→retry する
     setUser(me);
     return me;
   }, []);
 
-  // refresh -> me
+  // 「明示的に再取得したい」用途に残す（中身は fetchMe で十分）
   const reloadMe = useCallback(async (): Promise<User> => {
-    await refreshAccessToken(); // authAPI側で setAccessToken 済み
     return await fetchMe();
   }, [fetchMe]);
 
   // logout（API + tokenStoreクリア）-> userクリア
   const logout = useCallback(async () => {
     try {
-      await apiLogout(); // authAPI側で clearAccessToken 済み
+      await apiLogout();
     } finally {
       setUser(null);
     }
   }, []);
 
-  // 初回マウント時に復元を試みる
+  // 初回マウント時：authページでは復元しない（tokenexpired で無限に叩くのを防ぐ）
   useEffect(() => {
+    // /auth 配下（login/register/tokenexpired 等）は何もしない
+    if (pathname.startsWith("/auth")) {
+      setIsLoading(false);
+      return;
+    }
+
     (async () => {
       try {
-        await reloadMe();
+        await fetchMe();
       } catch {
-        // rt が無い / refresh失敗 / me失敗 → 未ログイン扱い
         setUser(null);
       } finally {
         setIsLoading(false);
       }
     })();
-  }, [reloadMe]);
+  }, [pathname, fetchMe]);
 
   const stateValue = useMemo<AuthState>(
     () => ({ user, isLoading }),

--- a/services/soso-web/src/requests/core/client.ts
+++ b/services/soso-web/src/requests/core/client.ts
@@ -2,13 +2,12 @@
 import axios, {
   type AxiosRequestConfig,
   type InternalAxiosRequestConfig,
-  type AxiosResponse,
   AxiosHeaders,
 } from "axios";
 import Cookies from "js-cookie";
 import { getAccessToken, clearAccessToken } from "./tokenStore";
 
-// _auth/_csrf を AxiosRequestConfig に追加
+// 型定義
 export type ApiRequestConfig<D = any> = AxiosRequestConfig<D> & {
   _auth?: boolean;
   _csrf?: boolean;
@@ -76,9 +75,8 @@ apiClient.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
-// ✅ response は標準の AxiosResponse のまま返す
 apiClient.interceptors.response.use(
-  (response: AxiosResponse) => response,
+  (response) => response.data,
   (error) => {
     if (axios.isAxiosError(error) && error.response?.status === 401) {
       clearAccessToken();
@@ -87,14 +85,9 @@ apiClient.interceptors.response.use(
   }
 );
 
-// ===== 型安全な API 関数（ここが「data を返す」）=====
-
-export async function apiGet<T>(
-  url: string,
-  config?: ApiRequestConfig
-): Promise<T> {
-  const res = await apiClient.get<T>(url, config);
-  return res.data;
+// ✅ ここから追加：typed wrapper
+export async function apiGet<T>(url: string, config?: ApiRequestConfig): Promise<T> {
+  return apiClient.get(url, config) as unknown as T;
 }
 
 export async function apiPost<T, D = unknown>(
@@ -102,8 +95,7 @@ export async function apiPost<T, D = unknown>(
   data?: D,
   config?: ApiRequestConfig<D>
 ): Promise<T> {
-  const res = await apiClient.post<T>(url, data, config);
-  return res.data;
+  return apiClient.post(url, data, config) as unknown as T;
 }
 
 export async function apiPut<T, D = unknown>(
@@ -111,8 +103,7 @@ export async function apiPut<T, D = unknown>(
   data?: D,
   config?: ApiRequestConfig<D>
 ): Promise<T> {
-  const res = await apiClient.put<T>(url, data, config);
-  return res.data;
+  return apiClient.put(url, data, config) as unknown as T;
 }
 
 export async function apiPatch<T, D = unknown>(
@@ -120,14 +111,9 @@ export async function apiPatch<T, D = unknown>(
   data?: D,
   config?: ApiRequestConfig<D>
 ): Promise<T> {
-  const res = await apiClient.patch<T>(url, data, config);
-  return res.data;
+  return apiClient.patch(url, data, config) as unknown as T;
 }
 
-export async function apiDelete<T>(
-  url: string,
-  config?: ApiRequestConfig
-): Promise<T> {
-  const res = await apiClient.delete<T>(url, config);
-  return res.data;
+export async function apiDelete<T>(url: string, config?: ApiRequestConfig): Promise<T> {
+  return apiClient.delete(url, config) as unknown as T;
 }

--- a/services/soso-web/src/requests/core/client.ts
+++ b/services/soso-web/src/requests/core/client.ts
@@ -1,13 +1,17 @@
-// src/requests/core/client.ts
 import axios, {
   type AxiosRequestConfig,
   type InternalAxiosRequestConfig,
+  type AxiosResponse,
   AxiosHeaders,
 } from "axios";
 import Cookies from "js-cookie";
-import { getAccessToken, clearAccessToken } from "./tokenStore";
+import {
+  getAccessToken,
+  setAccessToken,
+  clearAccessToken,
+} from "./tokenStore";
 
-// 型定義
+// _auth/_csrf を AxiosRequestConfig に追加
 export type ApiRequestConfig<D = any> = AxiosRequestConfig<D> & {
   _auth?: boolean;
   _csrf?: boolean;
@@ -16,9 +20,11 @@ export type ApiRequestConfig<D = any> = AxiosRequestConfig<D> & {
 type InternalApiConfig = InternalAxiosRequestConfig & {
   _auth?: boolean;
   _csrf?: boolean;
+  _retry?: boolean; // retry 制御（内部用）
 };
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080";
+const BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080";
 
 export const apiClient = axios.create({
   baseURL: BASE_URL,
@@ -26,7 +32,9 @@ export const apiClient = axios.create({
   withCredentials: true,
 });
 
-// ==== CSRFトークン管理 ====
+// ==============================
+// CSRF token
+// ==============================
 let csrfTokenPromise: Promise<string> | null = null;
 
 async function ensureCsrfToken(): Promise<string> {
@@ -49,7 +57,65 @@ async function ensureCsrfToken(): Promise<string> {
   return csrfTokenPromise;
 }
 
-// ==== Interceptors ====
+// ==============================
+// tokenexpired redirect
+// ==============================
+let redirected = false;
+
+function shouldSkipRedirect() {
+  if (typeof window === "undefined") return true;
+  return window.location.pathname.startsWith("/auth");
+}
+
+function redirectToTokenExpiredOnce() {
+  if (typeof window === "undefined") return;
+  if (redirected) return;
+  if (shouldSkipRedirect()) return;
+
+  redirected = true;
+  clearAccessToken();
+
+  const next = window.location.pathname + window.location.search;
+  window.location.assign(
+    `/auth/tokenexpired?next=${encodeURIComponent(next)}`
+  );
+}
+
+// auth系 endpoint は refresh で救わない（ループ源になりやすい）
+function isAuthEndpoint(url?: string): boolean {
+  if (!url) return false;
+  return (
+    url.includes("/auth/login") ||
+    url.includes("/auth/logout") ||
+    url.includes("/auth/csrf") ||
+    url.includes("/auth/refresh")
+  );
+}
+
+// ==============================
+// refresh (bypass apiClient interceptors)
+// ==============================
+type TokenResponse = {
+  access_token: string;
+  access_expires_at: string;
+};
+
+const refreshClient = axios.create({
+  baseURL: BASE_URL,
+  timeout: 10_000,
+  withCredentials: true,
+});
+
+async function refreshOnce(): Promise<void> {
+  const res = await refreshClient.post<TokenResponse>("/auth/refresh");
+  setAccessToken(res.data.access_token, res.data.access_expires_at);
+}
+
+let refreshPromise: Promise<void> | null = null;
+
+// ==============================
+// Interceptors: request
+// ==============================
 apiClient.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
     const cfg = config as InternalApiConfig;
@@ -58,11 +124,13 @@ apiClient.interceptors.request.use(
     const method = (cfg.method ?? "get").toUpperCase();
     const isMutating = ["POST", "PUT", "PATCH", "DELETE"].includes(method);
 
+    // CSRF
     if (isMutating || cfg._csrf) {
       const token = await ensureCsrfToken();
       if (token) cfg.headers.set("X-CSRF-Token", token);
     }
 
+    // Authorization
     if (cfg._auth) {
       const token = getAccessToken();
       if (token) cfg.headers.set("Authorization", `Bearer ${token}`);
@@ -75,19 +143,71 @@ apiClient.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
+// ==============================
+// Interceptors: response
+// 401/403 -> refresh(1回) -> retry(1回)
+// refresh 失敗 -> tokenexpired
+// ==============================
 apiClient.interceptors.response.use(
-  (response) => response.data,
-  (error) => {
-    if (axios.isAxiosError(error) && error.response?.status === 401) {
-      clearAccessToken();
+  (response: AxiosResponse) => response,
+  async (error) => {
+    if (!axios.isAxiosError(error)) return Promise.reject(error);
+
+    const status = error.response?.status;
+    const cfg = error.config as InternalApiConfig | undefined;
+    if (!cfg) return Promise.reject(error);
+
+    if (status !== 401 && status !== 403) {
+      return Promise.reject(error);
     }
-    return Promise.reject(error);
+
+    // auth系は refresh 対象外（ここで tokenexpired に寄せる）
+    if (isAuthEndpoint(cfg.url)) {
+      // /auth 配下ではリダイレクト抑制してある
+      redirectToTokenExpiredOnce();
+      return Promise.reject(error);
+    }
+
+    // 既にリトライ済み
+    if (cfg._retry) {
+      redirectToTokenExpiredOnce();
+      return Promise.reject(error);
+    }
+
+    cfg._retry = true;
+
+    try {
+      if (!refreshPromise) {
+        refreshPromise = refreshOnce().finally(() => {
+          refreshPromise = null;
+        });
+      }
+      await refreshPromise;
+
+      // refresh 後に token が無いなら retry しても無理
+      const token = getAccessToken();
+      if (!token) {
+        redirectToTokenExpiredOnce();
+        return Promise.reject(error);
+      }
+
+      return apiClient.request(cfg);
+    } catch (e) {
+      redirectToTokenExpiredOnce();
+      return Promise.reject(e);
+    }
   }
 );
 
-// ✅ ここから追加：typed wrapper
-export async function apiGet<T>(url: string, config?: ApiRequestConfig): Promise<T> {
-  return apiClient.get(url, config) as unknown as T;
+// ==============================
+// Typed API helpers (return data)
+// ==============================
+export async function apiGet<T>(
+  url: string,
+  config?: ApiRequestConfig
+): Promise<T> {
+  const res = await apiClient.get<T>(url, config);
+  return res.data;
 }
 
 export async function apiPost<T, D = unknown>(
@@ -95,7 +215,8 @@ export async function apiPost<T, D = unknown>(
   data?: D,
   config?: ApiRequestConfig<D>
 ): Promise<T> {
-  return apiClient.post(url, data, config) as unknown as T;
+  const res = await apiClient.post<T>(url, data, config);
+  return res.data;
 }
 
 export async function apiPut<T, D = unknown>(
@@ -103,7 +224,8 @@ export async function apiPut<T, D = unknown>(
   data?: D,
   config?: ApiRequestConfig<D>
 ): Promise<T> {
-  return apiClient.put(url, data, config) as unknown as T;
+  const res = await apiClient.put<T>(url, data, config);
+  return res.data;
 }
 
 export async function apiPatch<T, D = unknown>(
@@ -111,9 +233,14 @@ export async function apiPatch<T, D = unknown>(
   data?: D,
   config?: ApiRequestConfig<D>
 ): Promise<T> {
-  return apiClient.patch(url, data, config) as unknown as T;
+  const res = await apiClient.patch<T>(url, data, config);
+  return res.data;
 }
 
-export async function apiDelete<T>(url: string, config?: ApiRequestConfig): Promise<T> {
-  return apiClient.delete(url, config) as unknown as T;
+export async function apiDelete<T>(
+  url: string,
+  config?: ApiRequestConfig
+): Promise<T> {
+  const res = await apiClient.delete<T>(url, config);
+  return res.data;
 }


### PR DESCRIPTION
## 目的 / 背景
<!-- なぜこの変更が必要か。関連Issueがあれば #番号 を記載 -->

## 変更点
<!-- 主要なコード/設定の変更を列挙 -->
- 

## 動作確認
<!-- 再現/確認手順、期待結果、スクショ/動画 -->
1. 
2. 

## 影響範囲
- フロント / API / DB / インフラ

## 互換性・移行
- 破壊的変更: あり / なし
- Migration / 環境変数の変更: あり / なし

## セキュリティ / パフォーマンス
- 権限・認可の確認ポイント:
- 重い処理の有無・計測:

## チェックリスト
- [ ] 単体/結合/E2E テストを追加/更新した
- [ ] Lint/Format が通る
- [ ] ドキュメント・OpenAPI を更新した
- [ ] リリースノートに追記した

## 関連
- Close #

# .github/PULL_REQUEST_TEMPLATE/feature.md
## 種別
- [x] Feature
- [ ] Breaking

（以下は共通テンプレと同様）

# .github/PULL_REQUEST_TEMPLATE/bugfix.md
## 種別
- [x] Bugfix
- [ ] Hotfix