### PR TITLE
Feat/kanba/132/change model layer

### DIFF
--- a/services/soso-api/internal/config/router.go
+++ b/services/soso-api/internal/config/router.go
@@ -136,6 +136,7 @@ func SetupRouter(cfg *Config) *echo.Echo {
 	eveG.GET("/:event_id", eventH.FindById)
 	eveG.POST("/:event_id/pickup", eventH.RegisterPickUp)
 	eveG.POST("/:event_id/return", eventH.RegisterReturn)
+	eveG.POST("/:event_id/both", eventH.RegisterBoth)
 	eveG.GET("/:event_id/detail", eventH.Detail)
 	eveG.GET("/:event_id/members", eventH.Members)
 	eveG.GET("/dispatch/me", calenderH.FindMyTransportEvents)

--- a/services/soso-api/internal/handlers/event.go
+++ b/services/soso-api/internal/handlers/event.go
@@ -121,15 +121,12 @@ func (h *EventHandler) Create(c echo.Context) error {
 	}
 
 	// 参加者
-	registered := time.Now()
 	parts := make([]model.EventParticipant, len(req.ParticipantUserIDs))
 	for i, uid := range req.ParticipantUserIDs {
 		parts[i] = model.EventParticipant{
-			EventID:      ev.ID,
-			UserID:       uid,
-			Status:       model.Registered,
-			Type:         model.Participants,
-			RegisteredAt: registered,
+			EventID:           ev.ID,
+			UserID:            uid,
+			ParticipantStatus: true,
 		}
 	}
 	if err := h.EventParticipantRepo.BulkInsert(c.Request().Context(), parts); err != nil {
@@ -153,13 +150,15 @@ func (h *EventHandler) FindById(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, "event not found")
 	}
 	// 参加者
-	ps, err := h.EventParticipantRepo.FindByEventIDAndType(c.Request().Context(), eid, model.Participants)
+	ps, err := h.EventParticipantRepo.FindByEventID(c.Request().Context(), eid)
 	if err != nil {
 		return err
 	}
-	ids := make([]string, len(ps))
-	for i, p := range ps {
-		ids[i] = p.UserID
+	var ids []string
+	for _, p := range ps {
+		if p.ParticipantStatus {
+			ids = append(ids, p.UserID)
+		}
 	}
 	resp := baseEventResponse(ev)
 	resp["participantUserIds"] = ids
@@ -181,32 +180,37 @@ func (h *EventHandler) ListByCalender(c echo.Context) error {
 }
 
 /*
-	-------------------------------------------------------------
-	  POST /events/:event_id/pickup   (迎え登録)
+-------------------------------------------------------------
+
+	POST /events/:event_id/pickup   (迎え登録)
 
 -------------------------------------------------------------
 */
 func (h *EventHandler) RegisterPickUp(c echo.Context) error {
-	return h.registerParticipant(c, model.Go) // Type.Go
+	return h.registerDriver(c, func(ep *model.EventParticipant) {
+		ep.ParticipantStatus = true
+		ep.GoDriverStatus = true
+	})
 }
 
-/*
-	-------------------------------------------------------------
-	  POST /events/:event_id/return  (送り登録)
-
--------------------------------------------------------------
-*/
 func (h *EventHandler) RegisterReturn(c echo.Context) error {
-	return h.registerParticipant(c, model.Return) // Type.Return
+	return h.registerDriver(c, func(ep *model.EventParticipant) {
+		ep.ParticipantStatus = true
+		ep.ReturnDriverStatus = true
+	})
 }
 
-/*
-=============================================================
+func (h *EventHandler) RegisterBoth(c echo.Context) error {
+	return h.registerDriver(c, func(ep *model.EventParticipant) {
+		ep.ParticipantStatus = true
+		ep.ReturnDriverStatus = true
+		ep.GoDriverStatus = true
+	})
+}
 
-	共通ロジック
-	=============================================================
-*/
-func (h *EventHandler) registerParticipant(c echo.Context, tp model.Type) error {
+// registerDriver は認証→EventParticipant組み立て→Upsert の共通ロジック。
+// setFields で呼び出し元がどの boolean を立てるか決める。
+func (h *EventHandler) registerDriver(c echo.Context, setFields func(*model.EventParticipant)) error {
 	eventID := c.Param("event_id")
 
 	/* ---- 認証ユーザ ID ---- */
@@ -220,19 +224,14 @@ func (h *EventHandler) registerParticipant(c echo.Context, tp model.Type) error 
 	}
 	userID := claims.Subject
 
-	/* ---- 1 行だけ Insert ---- */
+	/* ---- Upsert ---- */
 	ep := model.EventParticipant{
-		EventID:      eventID,
-		UserID:       userID,
-		Status:       model.Registered,
-		Type:         tp,
-		RegisteredAt: time.Now(),
+		EventID: eventID,
+		UserID:  userID,
 	}
+	setFields(&ep)
 
-	if err := h.EventParticipantRepo.BulkInsert(
-		c.Request().Context(),
-		[]model.EventParticipant{ep},
-	); err != nil {
+	if err := h.EventParticipantRepo.Upsert(c.Request().Context(), ep); err != nil {
 		return err
 	}
 	return c.NoContent(http.StatusCreated)
@@ -281,13 +280,12 @@ func (h *EventHandler) Detail(c echo.Context) error {
 		returnDrivers []DriverDTO
 	)
 	for _, inf := range infos {
-		switch inf.Type {
-		case model.Participants:
-			userNames = append(userNames, inf.UserName)
-		case model.Go:
+		userNames = append(userNames, inf.UserName)
+		if inf.GoDriverStatus {
 			goCapSum += inf.Capacity
 			goDrivers = append(goDrivers, DriverDTO{Username: inf.UserName, Capacity: inf.Capacity})
-		case model.Return:
+		}
+		if inf.ReturnDriverStatus {
 			returnCapSum += inf.Capacity
 			returnDrivers = append(returnDrivers, DriverDTO{Username: inf.UserName, Capacity: inf.Capacity})
 		}

--- a/services/soso-api/internal/model/event_participant.go
+++ b/services/soso-api/internal/model/event_participant.go
@@ -2,35 +2,14 @@ package model
 
 import "time"
 
-// -------------------------
-// ENUM 型
-// -------------------------
-
-// status 列に対応
-type Status string
-
-const (
-	Registered Status = "registered"
-	Cancelled  Status = "cancelled"
-)
-
-// type 列に対応
-type Type string
-
-const (
-	Participants Type = "participants"
-	Go           Type = "go"
-	Return       Type = "return"
-)
-
-// -------------------------
-// テーブル対応モデル
-// -------------------------
-
 type EventParticipant struct {
-	EventID      string    `db:"event_id"      json:"eventId"`
-	UserID       string    `db:"user_id"       json:"userId"`
-	Status       Status    `db:"status"        json:"status"`
-	Type         Type      `db:"type"          json:"type"`
-	RegisteredAt time.Time `db:"registered_at" json:"registeredAt"`
+	EventID            string    `db:"event_id"             json:"eventId"`
+	UserID             string    `db:"user_id"              json:"userId"`
+	ParticipantStatus  bool      `db:"participant_status"   json:"participantStatus"`
+	GoDriverStatus     bool      `db:"go_driver_status"     json:"goDriverStatus"`
+	ReturnDriverStatus bool      `db:"return_driver_status" json:"returnDriverStatus"`
+	GoRiderStatus      bool      `db:"go_rider_status"      json:"goRiderStatus"`
+	ReturnRiderStatus  bool      `db:"return_rider_status"  json:"returnRiderStatus"`
+	CreatedAt          time.Time `db:"created_at"           json:"createdAt"`
+	UpdatedAt          time.Time `db:"updated_at"           json:"updatedAt"`
 }

--- a/services/soso-api/internal/repository/event_participants.go
+++ b/services/soso-api/internal/repository/event_participants.go
@@ -36,27 +36,28 @@ func (r *EventParticipantRepository) BulkInsert(
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	defer func() {
-		// panic や中途 return に備えた保険
 		if p := recover(); p != nil {
 			_ = tx.Rollback()
 			panic(p)
 		}
 	}()
 
-	const cols = "(event_id, user_id, status, type, registered_at)"
+	const cols = "(event_id, user_id, participant_status, go_driver_status, return_driver_status, go_rider_status, return_rider_status)"
 	var (
 		valuePlaceholders []string
 		args              []interface{}
 	)
 
 	for _, ep := range participants {
-		valuePlaceholders = append(valuePlaceholders, "(?, ?, ?, ?, ?)")
+		valuePlaceholders = append(valuePlaceholders, "(?, ?, ?, ?, ?, ?, ?)")
 		args = append(args,
 			ep.EventID,
 			ep.UserID,
-			string(ep.Status), // ENUM は string として扱う
-			string(ep.Type),
-			ep.RegisteredAt,
+			ep.ParticipantStatus,
+			ep.GoDriverStatus,
+			ep.ReturnDriverStatus,
+			ep.GoRiderStatus,
+			ep.ReturnRiderStatus,
 		)
 	}
 
@@ -94,24 +95,56 @@ func isDuplicateError(err error) bool {
 	return false
 }
 
-func (r *EventParticipantRepository) FindByEventIDAndType(
+// Upsert inserts a new participant or updates the boolean status columns
+// if the (event_id, user_id) row already exists.
+func (r *EventParticipantRepository) Upsert(
+	ctx context.Context,
+	ep model.EventParticipant,
+) error {
+	const q = `
+		INSERT INTO event_participants
+			(event_id, user_id, participant_status,
+	go_driver_status, return_driver_status, go_rider_status,
+	return_rider_status)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE
+			participant_status    = VALUES(participant_status),
+			go_driver_status      = VALUES(go_driver_status),
+			return_driver_status  = VALUES(return_driver_status),     
+			go_rider_status       = VALUES(go_rider_status),          
+			return_rider_status   = VALUES(return_rider_status)
+	`
+
+	_, err := r.DB.ExecContext(ctx, q,
+		ep.EventID,            // 1つ目の ?
+		ep.UserID,             // 2つ目の ?
+		ep.ParticipantStatus,  // 3つ目の ?
+		ep.GoDriverStatus,     // 4つ目の ?
+		ep.ReturnDriverStatus, // 5つ目の ?
+		ep.GoRiderStatus,      // 6つ目の ?
+		ep.ReturnRiderStatus,  // 7つ目の ?
+	)
+
+	return err
+}
+
+// FindByEventID returns all participants for an event.
+func (r *EventParticipantRepository) FindByEventID(
 	ctx context.Context,
 	eventID string,
-	pt model.Type,
 ) ([]*model.EventParticipant, error) {
 
 	const q = `
 		SELECT
-			event_id,
-			user_id,
-			status,
-			type,
-			registered_at
+			event_id, user_id,
+			participant_status, go_driver_status, return_driver_status,
+			go_rider_status, return_rider_status,
+			created_at, updated_at
 		FROM event_participants
-		WHERE event_id = ? AND type = ?
+		WHERE event_id = ?
 	`
 
-	rows, err := r.DB.QueryContext(ctx, q, eventID, string(pt))
+	rows, err := r.DB.QueryContext(ctx, q, eventID)
 	if err != nil {
 		return nil, err
 	}
@@ -123,9 +156,13 @@ func (r *EventParticipantRepository) FindByEventIDAndType(
 		if err := rows.Scan(
 			&ep.EventID,
 			&ep.UserID,
-			&ep.Status,
-			&ep.Type,
-			&ep.RegisteredAt,
+			&ep.ParticipantStatus,
+			&ep.GoDriverStatus,
+			&ep.ReturnDriverStatus,
+			&ep.GoRiderStatus,
+			&ep.ReturnRiderStatus,
+			&ep.CreatedAt,
+			&ep.UpdatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -137,22 +174,20 @@ func (r *EventParticipantRepository) FindByEventIDAndType(
 	return list, nil
 }
 
-// 新規追加
-// ExistsByEventAndUser checks if a participant record exists for the given event and user
+// ExistsByEventAndUser checks if a participant record exists for the given event and user.
 func (r *EventParticipantRepository) ExistsByEventAndUser(
 	ctx context.Context,
 	eventID string,
 	userID string,
-	participantType model.Type,
 ) (bool, error) {
 	const q = `
 		SELECT COUNT(*)
 		FROM event_participants
-		WHERE event_id = ? AND user_id = ? AND type = ?
+		WHERE event_id = ? AND user_id = ?
 	`
 
 	var count int
-	err := r.DB.QueryRowContext(ctx, q, eventID, userID, string(participantType)).Scan(&count)
+	err := r.DB.QueryRowContext(ctx, q, eventID, userID).Scan(&count)
 	if err != nil {
 		return false, fmt.Errorf("check participant existence: %w", err)
 	}
@@ -162,23 +197,24 @@ func (r *EventParticipantRepository) ExistsByEventAndUser(
 
 /* 参加者とユーザー情報をまとめた DTO */
 type ParticipantInfo struct {
-	UserName string
-	Capacity int
-	Type     model.Type
+	UserName           string
+	Capacity           int
+	GoDriverStatus     bool
+	ReturnDriverStatus bool
 }
 
 // FetchUserInfos returns all participants of an event
-// together with their username and capacity.
+// together with their username, capacity, and driver statuses.
 func (r *EventParticipantRepository) FetchUserInfos(
 	ctx context.Context,
 	eventID string,
 ) ([]ParticipantInfo, error) {
 
 	const q = `
-		SELECT u.username, u.capacity, ep.type
+		SELECT u.username, u.capacity, ep.go_driver_status, ep.return_driver_status
 		FROM event_participants AS ep
 		INNER JOIN users AS u ON u.id = ep.user_id
-		WHERE ep.event_id = ?`
+		WHERE ep.event_id = ? AND ep.participant_status = 1`
 
 	rows, err := r.DB.QueryContext(ctx, q, eventID)
 	if err != nil {
@@ -189,7 +225,7 @@ func (r *EventParticipantRepository) FetchUserInfos(
 	var list []ParticipantInfo
 	for rows.Next() {
 		var p ParticipantInfo
-		if err := rows.Scan(&p.UserName, &p.Capacity, &p.Type); err != nil {
+		if err := rows.Scan(&p.UserName, &p.Capacity, &p.GoDriverStatus, &p.ReturnDriverStatus); err != nil {
 			return nil, err
 		}
 		list = append(list, p)
@@ -207,7 +243,7 @@ type MemberInfo struct {
 	SoSoPoint int
 }
 
-// FetchMemberInfos returns event members (type = "participants")
+// FetchMemberInfos returns event members (participant_status = 1)
 // with their SoSo points in the same calendar.
 func (r *EventParticipantRepository) FetchMemberInfos(
 	ctx context.Context,
@@ -221,7 +257,7 @@ func (r *EventParticipantRepository) FetchMemberInfos(
 		INNER JOIN calender_memberships AS cm
 		     ON cm.calender_id = e.calender_id AND cm.user_id = ep.user_id
 		INNER JOIN users AS u ON u.id = ep.user_id
-		WHERE ep.event_id = ? AND ep.type = 'participants'
+		WHERE ep.event_id = ? AND ep.participant_status = 1
 	`
 
 	rows, err := r.DB.QueryContext(ctx, q, eventID)


### PR DESCRIPTION
## Summary
  - EventParticipant モデルを type/status ENUM から boolean 
  列（participant_status, go_driver_status 等）に変更       
  - Repository の全メソッドを新スキーマに対応               
  - 役割変更を1クエリで処理する Upsert メソッドを新規追加   
  - FindByEventIDAndType → FindByEventID に変更（boolean    
  列で判別するため type フィルタ不要に）                    
                                                            
  ## Test plan                                              
  - [ ] Handler 層の対応（Phase 4）後にコンパイルが通ること
  - [ ] Upsert で新規登録・役割変更が正しく動作すること     
  - [ ] 既存テストの更新（Phase 8） 